### PR TITLE
Feature/python

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -1,9 +1,11 @@
-# GitHub workflow to enable continuous integratoin
+# GitHub workflow to enable continuous integration
 name: Continuous Integration
 
 # This workflow is triggered on pushes and pull requests to the repository.
-on: 
-  pull_request: 
+on:
+  push:
+    branches: '**'
+  pull_request:
     branches: 'master'
 
 jobs:
@@ -18,17 +20,25 @@ jobs:
     steps:
     - name: which CXX
       run: |
-        which ${{matrix.cxx}} 
+        which ${{matrix.cxx}}
         ${{matrix.cxx}} --version
     - uses: actions/checkout@v2
     - name: mkdir bin
-      run: mkdir bin 
+      run: mkdir bin
     - name: cmake
-      run: cmake -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} ..  
+      run: cmake -DPYTHON_EXECUTABLE=$(which python3) -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} ..
       working-directory: ./bin
     - name: make
-      run: make
+      run: make -j2
       working-directory: ./bin
     - name: ctest
       run: ctest -j2
       working-directory: ./bin
+    - name: make GNDStk.python
+      run: make GNDStk.python -j2
+      working-directory: ./bin
+    - name: python -m unittest
+      run: |
+        cp ../bin/*.so .
+        python3 -m unittest discover -v -p "Test*"
+      working-directory: ./python

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin*
 build
 *~
 metaconfigure/*.pyc
+docs/.build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ include( cmake/GNDStk_dependencies.cmake )
 # Project targets
 ########################################################################
 
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# GNDStk : library
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+include_directories( src/ )
+
 add_library( GNDStk INTERFACE )
 target_include_directories( GNDStk INTERFACE src/ )
 target_link_libraries( GNDStk
@@ -38,6 +44,21 @@ target_link_libraries( GNDStk
     INTERFACE nlohmann_json::nlohmann_json
     )
 
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# GNDStk : python bindings
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+include_directories( python/src/ )
+
+pybind11_add_module( GNDStk.python
+    EXCLUDE_FROM_ALL
+    python/src/GNDStk.python.cpp
+    )
+target_link_libraries( GNDStk.python PRIVATE GNDStk )
+target_compile_options( GNDStk.python PRIVATE "-fPIC" )
+target_compile_options( GNDStk.python PRIVATE "-fvisibility=hidden" )
+set_target_properties( GNDStk.python PROPERTIES OUTPUT_NAME GNDStk )
+set_target_properties( GNDStk.python PROPERTIES COMPILE_DEFINITIONS "PYBIND11" )
 
 #######################################################################
 # Top-level Only

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ include_directories( python/src/ )
 pybind11_add_module( GNDStk.python
     EXCLUDE_FROM_ALL
     python/src/GNDStk.python.cpp
+    python/src/core/Node.python.cpp
     )
 target_link_libraries( GNDStk.python PRIVATE GNDStk )
 target_compile_options( GNDStk.python PRIVATE "-fPIC" )

--- a/cmake/GNDStk_dependencies.cmake
+++ b/cmake/GNDStk_dependencies.cmake
@@ -41,6 +41,11 @@ if(NOT json_POPULATED)
   add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
+FetchContent_Declare( pybind11
+    GIT_REPOSITORY  https://github.com/pybind/pybind11
+    GIT_TAG         v2.6.1
+    GIT_SHALLOW     TRUE
+    )
 
 
 ########################################################################
@@ -52,4 +57,5 @@ FetchContent_MakeAvailable(
     Log
     pugixml-adapter
     json
+    pybind11
     )

--- a/python/runtests.sh
+++ b/python/runtests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# this script copies the dynamic library for the GNDStk python module
+# and runs all the unit tests it can find
+
+rm GNDStk.*.so
+cp ../build/GNDStk.*.so .
+python -m unittest discover -v -p "Test*"

--- a/python/src/GNDStk.python.cpp
+++ b/python/src/GNDStk.python.cpp
@@ -1,0 +1,29 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// other includes
+
+// namespace aliases
+namespace python = pybind11;
+
+/**
+ *  @brief GNDStk python bindings
+ *
+ *  The name given here (GNDStk) must be the same as the name
+ *  set on the PROPERTIES OUTPUT_NAME in the CMakeLists.txt file.
+ */
+PYBIND11_MODULE( GNDStk, module ) {
+
+  module.def(
+
+    "add",
+    [] ( int left, int right ) { return left + right; },
+    python::arg( "left" ), python::arg( "right" ),
+    "Return the sum of two integers\n\n"
+    "This function does not throw an exception.\n\n"
+    "Arguments:\n"
+    "    left    the integer on the left\n"
+    "    right   the integer on the right"
+  );
+}

--- a/python/src/GNDStk.python.cpp
+++ b/python/src/GNDStk.python.cpp
@@ -7,6 +7,12 @@
 // namespace aliases
 namespace python = pybind11;
 
+// core interface declarations
+namespace core {
+
+  void wrapNode( python::module& );
+}
+
 /**
  *  @brief GNDStk python bindings
  *
@@ -15,15 +21,13 @@ namespace python = pybind11;
  */
 PYBIND11_MODULE( GNDStk, module ) {
 
-  module.def(
+  // create the core submodule
+  python::module submodule = module.def_submodule(
 
-    "add",
-    [] ( int left, int right ) { return left + right; },
-    python::arg( "left" ), python::arg( "right" ),
-    "Return the sum of two integers\n\n"
-    "This function does not throw an exception.\n\n"
-    "Arguments:\n"
-    "    left    the integer on the left\n"
-    "    right   the integer on the right"
+    "core",
+    "core - GNDS core interface components"
   );
+
+  // wrap core components
+  core::wrapNode( submodule );
 }

--- a/python/src/core/Node.python.cpp
+++ b/python/src/core/Node.python.cpp
@@ -85,7 +85,45 @@ namespace core {
       },
       "The children of the node"
     )
-    // add a public member function
+    .def(
+
+      "add",
+      // we need to define one of these for every type we want to use since
+      // python does not have a concept of templates
+      [] ( Component& self, const std::string& name, const std::string& value )
+         { return self.add( name, value ); },
+      python::arg( "name" ), python::arg( "value" ),
+      "Add the name,value pair as metadata to the node.\n\n"
+      "Arguments:\n"
+      "    name    the name of the metadata\n"
+      "    value   the value of the metadata\n"
+    )    // add a public member function
+    .def(
+
+      "add",
+      // we need to define one of these for every type we want to use since
+      // python does not have a concept of templates
+      [] ( Component& self, const std::string& name, int value )
+         { return self.add( name, value ); },
+      python::arg( "name" ), python::arg( "value" ),
+      "Add the name,value pair as metadata to the node.\n\n"
+      "Arguments:\n"
+      "    name    the name of the metadata\n"
+      "    value   the value of the metadata\n"
+    )    // add a public member function
+    .def(
+
+      "add",
+      // we need to define one of these for every type we want to use since
+      // python does not have a concept of templates
+      [] ( Component& self, const std::string& name, double value )
+         { return self.add( name, value ); },
+      python::arg( "name" ), python::arg( "value" ),
+      "Add the name,value pair as metadata to the node.\n\n"
+      "Arguments:\n"
+      "    name    the name of the metadata\n"
+      "    value   the value of the metadata\n"
+    )    // add a public member function
     .def(
 
       "empty",

--- a/python/src/core/Node.python.cpp
+++ b/python/src/core/Node.python.cpp
@@ -1,0 +1,72 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// local includes
+#include "GNDStk.hpp"
+
+// namespace aliases
+namespace python = pybind11;
+
+namespace core {
+
+  void wrapNode( python::module& module ) {
+
+    // type aliases
+    using Component = njoy::GNDStk::core::Node;
+
+    // create the core component
+    python::class_< Component > component(
+
+      module,
+      "Node",
+      "GNDS core node"
+    );
+
+    // wrap the core component
+    component
+    // add the default Node constructor to the python class
+    .def(
+
+      python::init<>(),
+      "Initialise an empty node\n\n"
+      "Arguments:\n"
+      "    self   the node"
+    )
+    // add the Node constructor using a string argument to the python class
+    .def(
+
+      python::init< const std::string& >(),
+      python::arg( "name" ),
+      "Initialise the node with its name\n\n"
+      "Arguments:\n"
+      "    self   the node\n"
+      "    name   the name of the node"
+    )
+    // add the copy constructor to the python class
+    .def(
+
+      python::init< const Component& >(),
+      python::arg( "name" ),
+      "Initialise the node with a copy of a node\n\n"
+      "Arguments:\n"
+      "    self   the node\n"
+      "    copy   the node to be copied"
+    )
+    // add a public member/field with read only access
+    // you can use def_readwrite to make it read/write
+    .def_readonly(
+
+      "name",
+      &Component::name,
+      "The name of the node"
+    )
+    // add a public member function
+    .def(
+
+      "empty",
+      &Component::empty,
+      "Return whether or not the node is empty"
+    );
+  }
+}

--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -1,0 +1,1 @@
+# empty __init__.py

--- a/python/test/core/Test_GNDStk_core_Node.py
+++ b/python/test/core/Test_GNDStk_core_Node.py
@@ -1,0 +1,28 @@
+# standard imports
+import unittest
+
+# third party imports
+
+# local imports
+from GNDStk.core import Node
+
+class Test_GNDStk_core_Node( unittest.TestCase ) :
+    """Unit test for the Node class."""
+
+    def test_constructors( self ) :
+
+        n = Node()
+        self.assertEqual( '', n.name )
+        self.assertEqual( True, n.empty() )
+
+        n = Node( Node() )
+        self.assertEqual( '', n.name )
+        self.assertEqual( True, n.empty() )
+
+        n = Node( name = 'NodeName' )
+        self.assertEqual( 'NodeName', n.name )
+        self.assertEqual( False, n.empty() )
+
+if __name__ == '__main__' :
+
+    unittest.main()

--- a/python/test/core/Test_GNDStk_core_Node.py
+++ b/python/test/core/Test_GNDStk_core_Node.py
@@ -32,6 +32,38 @@ class Test_GNDStk_core_Node( unittest.TestCase ) :
         self.assertEqual( False, n.empty() )
         self.assertEqual( 'NodeName:', n.to_string() )
 
+    def test_add( self ) :
+
+        n = Node( 'name' )
+
+        n.add( 'one', 'two' )
+        self.assertEqual( 1, len( n.metadata ) )
+        self.assertEqual( [ ( 'one', 'two' ) ], n.metadata )
+
+        n.add( '1', '2' )
+        self.assertEqual( 2, len( n.metadata ) )
+        self.assertEqual( [ ( 'one', 'two' ), ( '1', '2' ) ], n.metadata )
+
+        pair = n.add( 'foobar', 'foo bar' )
+        self.assertEqual( 3, len( n.metadata ) )
+        self.assertEqual( [ ( 'one', 'two' ), ( '1', '2' ),
+                            ( 'foobar', 'foo bar' ) ],
+                          n.metadata )
+
+        self.assertEqual( ( 'foobar', 'foo bar' ), pair )
+
+        n.add( '3', 4 )
+        self.assertEqual( 4, len( n.metadata ) )
+        self.assertEqual( [ ( 'one', 'two' ), ( '1', '2' ),
+                            ( 'foobar', 'foo bar' ),
+                            ( '3', '4' ) ], n.metadata )
+
+        n.add( '5', 6.01 )
+        self.assertEqual( 5, len( n.metadata ) )
+        self.assertEqual( [ ( 'one', 'two' ), ( '1', '2' ),
+                            ( 'foobar', 'foo bar' ),
+                            ( '3', '4' ), ( '5', '6.01' ) ], n.metadata )
+
     def test_clear( self ) :
 
         n = Node()

--- a/python/test/core/Test_GNDStk_core_Node.py
+++ b/python/test/core/Test_GNDStk_core_Node.py
@@ -13,15 +13,44 @@ class Test_GNDStk_core_Node( unittest.TestCase ) :
 
         n = Node()
         self.assertEqual( '', n.name )
+        self.assertEqual( 0, len( n.metadata ) )
+        self.assertEqual( 0, len( n.children ) )
         self.assertEqual( True, n.empty() )
+        self.assertEqual( '', n.to_string() )
 
         n = Node( Node() )
         self.assertEqual( '', n.name )
+        self.assertEqual( 0, len( n.metadata ) )
+        self.assertEqual( 0, len( n.children ) )
         self.assertEqual( True, n.empty() )
+        self.assertEqual( '', n.to_string() )
 
         n = Node( name = 'NodeName' )
         self.assertEqual( 'NodeName', n.name )
+        self.assertEqual( 0, len( n.metadata ) )
+        self.assertEqual( 0, len( n.children ) )
         self.assertEqual( False, n.empty() )
+        self.assertEqual( 'NodeName:', n.to_string() )
+
+    def test_clear( self ) :
+
+        n = Node()
+        ref = n.clear()
+
+        # verifies that ref and n are still the same object
+        self.assertEqual( True, ref is n )
+
+        # ref and n are empty nodes
+        self.assertEqual( '', n.name )
+        self.assertEqual( 0, len( n.metadata ) )
+        self.assertEqual( 0, len( ref.children ) )
+        self.assertEqual( True, n.empty() )
+        self.assertEqual( '', n.to_string() )
+        self.assertEqual( '', ref.name )
+        self.assertEqual( 0, len( ref.metadata ) )
+        self.assertEqual( 0, len( ref.children ) )
+        self.assertEqual( True, ref.empty() )
+        self.assertEqual( '', ref.to_string() )
 
 if __name__ == '__main__' :
 

--- a/python/test/core/__init__.py
+++ b/python/test/core/__init__.py
@@ -1,0 +1,1 @@
+# empty __init__.py


### PR DESCRIPTION
Setting up CMake for using pybind11, also provides some rudimentary bindings for the Node operator and python unit tests as well.

To compile the python module, you must use the GNDStk.python in the make command explicitly (the python module is excluded from the all target to prevent it from compiling when you compile projects that use the C++ GNDStk).
For example:
make GNDStk.python -j8

To run the python unit test, you should go into the python subdirectory and just run the runtests.sh script.

