### PR TITLE
Gave class Node a parent-node pointer.

### DIFF
--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1026,7 +1026,9 @@ void make_class(
    // save content
    if (debugging)
       std::cout << "ndep.name == " << ndep.name << std::endl;
-   assert(classMap.insert(std::make_pair(ndep.name,oss.str())).second);
+   const bool inserted =
+      classMap.insert(std::make_pair(ndep.name,oss.str())).second;
+   assert(inserted);
 }
 
 

--- a/src/GNDStk.hpp
+++ b/src/GNDStk.hpp
@@ -17,6 +17,7 @@
 
 // miscellaneous
 #include <algorithm>
+#undef NDEBUG
 #include <cassert>
 #include <cctype>
 #include <chrono>

--- a/src/GNDStk/Component/src/query.hpp
+++ b/src/GNDStk/Component/src/query.hpp
@@ -38,7 +38,7 @@ void query(const Node &node) const
          // consistency check
          assert(0 == links.size());
       } else {
-         // retrieve node's data by doing a multi-query
+         // retrieve the node's data by doing a multi-query
          const auto tup = node(toKeywordTup(DERIVED::keys()));
 
          // consistency check

--- a/src/GNDStk/Component/src/write.hpp
+++ b/src/GNDStk/Component/src/write.hpp
@@ -67,7 +67,7 @@ std::ostream &write(std::ostream &os, const int level = 0) const
                         links[n++],
                         detail::getName(key),
                         maxlen
-                     ) && (os << '\n') // well OK; no "if" in fold expression :-/
+                     ) && (os << '\n') // no "if" in fold expression :-/
                   ),
                   ...
                );

--- a/src/GNDStk/Node.hpp
+++ b/src/GNDStk/Node.hpp
@@ -18,11 +18,16 @@ public:
 
    // Simple node for our tree structure:
    //    name
-   //    metadata (container of string pairs)
-   //    children (container of pointers to other Nodes)
+   //    metadata   (container of string pairs)
+   //    children   (container of pointers to other Nodes)
+   //    parentNode (pointer to parent node)
    std::string name;
    std::vector<metaPair> metadata;
    std::vector<childPtr> children;
+private:
+   // Private, because users really shouldn't deal with it; use parent()
+   Node *parentNode = nullptr;
+public:
 
    // ------------------------
    // Simple functions
@@ -42,6 +47,11 @@ public:
    {
       return name == "" && metadata.size() == 0 && children.size() == 0;
    }
+
+   // parent
+   // Assumes that this Node's constness determines its parent's constness
+   const Node &parent() const { return *parentNode; }
+         Node &parent()       { return *parentNode; }
 
    // ------------------------
    // General functions
@@ -125,6 +135,18 @@ public:
    // ------------------------
 
    #include "GNDStk/Node/src/subscript.hpp"
+
+   // ------------------------
+   // destructor
+   // ------------------------
+
+   ~Node()
+   {
+      // Ensure that each child has the current Node as a parent.
+      // fixme This is just a validity check; consider removing it.
+      for (auto &c : children)
+         assert(c->parentNode == this);
+   }
 
 }; // class Node
 

--- a/src/GNDStk/Node/src/add-child.hpp
+++ b/src/GNDStk/Node/src/add-child.hpp
@@ -9,7 +9,7 @@
 // Remark. Some of the Child add()s accept a general ALLOW Child (either
 // Allow::one or Allow::many) along with just *one* value. The Allow::many
 // is permissible here - even with just one value - because we could certainly
-// wish to add multiple values one-by-one.
+// intend to add multiple values one-by-one.
 //
 // Naturally, we'll also have add() functions that accept only an Allow::many
 // Child, and receive containers of values.
@@ -31,9 +31,10 @@
 Node &add(const std::string &name = "")
 {
    children.push_back(std::make_unique<Node>());
-   Node &n = *children.back();
-   n.name = name;
-   return n;
+   Node &newChild = *children.back();
+   newChild.name = name;
+   newChild.parentNode = this;
+   return newChild;
 }
 
 // 1-argument: plain
@@ -70,7 +71,7 @@ Node &add(const Defaulted<T> &def)
 // -----------------------------------------------------------------------------
 
 // Similar in principle to its Meta counterpart. Bounces to one of the above
-// add() functions; and like those, doesn't allow std::optional.
+// add() functions; and, like those, doesn't allow std::optional.
 
 // Child<void>, plain
 // Child<void>, Defaulted

--- a/src/GNDStk/Node/src/assign.hpp
+++ b/src/GNDStk/Node/src/assign.hpp
@@ -4,12 +4,29 @@
 // -----------------------------------------------------------------------------
 
 // move
-Node &operator=(Node &&) = default;
+Node &operator=(Node &&other)
+{
+   if (&other != this) {
+      name = std::move(other.name);
+      metadata = std::move(other.metadata);
+      children = std::move(other.children);
+      for (auto &c : children)
+         c->parentNode = this;
+   }
+   return *this;
+}
 
 // copy
-Node &operator=(const Node &from)
+Node &operator=(const Node &other)
 {
-   if (&from != this)
-      detail::node2Node(from,*this);
+   if (&other != this) {
+      // The following uses add()s to add child nodes. The add()s,
+      // in turn, ensure that the parentNode pointers are correct.
+      detail::node2Node(other,*this);
+
+      // validate
+      for (auto &c : children)
+         assert(c->parentNode = this);
+   }
    return *this;
 }

--- a/src/GNDStk/Node/src/child.hpp
+++ b/src/GNDStk/Node/src/child.hpp
@@ -12,7 +12,7 @@
 // The Child encodes the notion that any number of child nodes of this name
 // can occur. In these cases the child() functions return containers of values.
 //
-// Non-const versions aren't needed for most, as they return by value.
+// Non-const versions aren't needed for most of these, as they return by value.
 // -----------------------------------------------------------------------------
 
 

--- a/src/GNDStk/Node/src/detail.hpp
+++ b/src/GNDStk/Node/src/detail.hpp
@@ -6,8 +6,8 @@ namespace detail {
 // put this forward declaration into the file in which *those* are defined, but
 // that file is #included inside class Node { ... }'s definition, where writing
 // the forward declaration wouldn't make sense.
-template<class NODEFROM, class NODETO>
-void node2Node(const NODEFROM &, NODETO &);
+template<class NODE>
+void node2Node(const NODE &, NODE &);
 
 
 

--- a/src/GNDStk/Node/src/shuffle.hpp
+++ b/src/GNDStk/Node/src/shuffle.hpp
@@ -1,6 +1,6 @@
 
 // -----------------------------------------------------------------------------
-// Randomly shuffle the metadata and child nodes. This capability should
+// Randomly shuffle the metadata and children. This capability should
 // be helpful for validating functions like Node's sort() and operator==.
 // -----------------------------------------------------------------------------
 

--- a/src/GNDStk/Node/src/write.hpp
+++ b/src/GNDStk/Node/src/write.hpp
@@ -17,6 +17,12 @@ std::ostream &write(std::ostream &os, const int level = 0) const
    if (!(os << icurr << name << ":"))
       log::error("ostream << Node.name returned with !ostream");
 
+   // possibly write address and parent-node information
+   if (parents)
+      if (!(os << " (address " << this << ", parent " << &parent() << ")"))
+         log::error("ostream << (Node address/parent information) "
+                    "returned with !ostream");
+
    // write metadata
    if (os)
       for (const auto &meta : metadata)

--- a/src/GNDStk/Node/test/child.test.cpp
+++ b/src/GNDStk/Node/test/child.test.cpp
@@ -176,8 +176,8 @@ SCENARIO("Testing GNDStk Node child()") {
 
          CHECK(iso_bar_node.size() == 1);
          CHECK(iso_bar_node[0].bar_id == "H2");
-      }
-   }
+      } // WHEN
+   } // GIVEN
 
 
    // ------------------------

--- a/src/GNDStk/Tree.hpp
+++ b/src/GNDStk/Tree.hpp
@@ -6,8 +6,6 @@
 // -----------------------------------------------------------------------------
 
 class Tree : public Node {
-   using nodeType = Node;
-
 public:
 
    // ------------------------
@@ -17,13 +15,13 @@ public:
    // clear
    Tree &clear()
    {
-      return this->nodeType::clear(), *this;
+      return this->Node::clear(), *this;
    }
 
    // sort
    Tree &sort()
    {
-      return this->nodeType::sort(), *this;
+      return this->Node::sort(), *this;
    }
 
    // ------------------------

--- a/src/GNDStk/Tree/src/ctor.hpp
+++ b/src/GNDStk/Tree/src/ctor.hpp
@@ -10,7 +10,7 @@ Tree() = default;
 Tree(Tree &&) = default;
 
 // copy
-Tree(const Tree &from) : nodeType{}
+Tree(const Tree &from) : Node{}
 {
    try {
       if (!convert(from,*this))

--- a/src/GNDStk/Tree/src/decl.hpp
+++ b/src/GNDStk/Tree/src/decl.hpp
@@ -4,7 +4,7 @@
 // -----------------------------------------------------------------------------
 
 // const
-const nodeType &decl() const
+const Node &decl() const
 {
    try {
       if (!has_decl()) {
@@ -23,7 +23,7 @@ const nodeType &decl() const
 }
 
 // non-const
-nodeType &decl()
+Node &decl()
 {
-   return const_cast<nodeType &>(std::as_const(*this).decl());
+   return const_cast<Node &>(std::as_const(*this).decl());
 }

--- a/src/GNDStk/Tree/src/reset.hpp
+++ b/src/GNDStk/Tree/src/reset.hpp
@@ -51,16 +51,16 @@ Tree &reset(
        || form == FileType::tree
       ) {
          // xml, null, tree
-         nodeType::add("xml");
+         add("xml");
          decl().add("version",  detail::sent(version ) ? version  : "1.0"  );
          decl().add("encoding", detail::sent(encoding) ? encoding : "UTF-8");
       } else if (form == FileType::json) {
          // json
-         nodeType::add("json");
+         add("json");
          // any use for version and encoding?
       } else if (form == FileType::hdf5) {
          // hdf5
-         nodeType::add("hdf5");
+         add("hdf5");
          // any use for version and encoding?
       } else {
          log::error(
@@ -73,7 +73,7 @@ Tree &reset(
       }
 
       // GNDS node: "reactionSuite", etc.
-      nodeType::add(kwd.name);
+      add(kwd.name);
       return *this;
 
    } catch (...) {

--- a/src/GNDStk/Tree/src/top.hpp
+++ b/src/GNDStk/Tree/src/top.hpp
@@ -4,7 +4,7 @@
 // -----------------------------------------------------------------------------
 
 // const
-const nodeType &top() const
+const Node &top() const
 {
    try {
       if (!has_top()) {
@@ -23,7 +23,7 @@ const nodeType &top() const
 }
 
 // non-const
-nodeType &top()
+Node &top()
 {
-   return const_cast<nodeType &>(std::as_const(*this).top());
+   return const_cast<Node &>(std::as_const(*this).top());
 }

--- a/src/GNDStk/Tree/test/assign.test.cpp
+++ b/src/GNDStk/Tree/test/assign.test.cpp
@@ -35,7 +35,7 @@ SCENARIO("Testing GNDStk tree assignments")
       WHEN("We try Tree's move assignment") {
          left = Tree("n-069_Tm_170-covar.xml");
          std::ostringstream ossl; ossl << left;
-         Tree right("n-069_Tm_170-covar.xml");
+         const Tree right("n-069_Tm_170-covar.xml");
          std::ostringstream ossr; ossr << right;
          CHECK(ossl.str() == ossr.str());
       }

--- a/src/GNDStk/Tree/test/call.test.cpp
+++ b/src/GNDStk/Tree/test/call.test.cpp
@@ -188,11 +188,11 @@ SCENARIO("Testing GNDStk Tree operator()") {
          // At present, need to split and use child() (...) in
          // order to <direct-specify> an output container type
          found = false;
-         auto dq =
+         auto deq =
             tree(reactionSuite,reactions).
             child<std::deque>(reaction,found);
          CHECK(found);
-         CHECK(dq.size() == 60);
+         CHECK(deq.size() == 60);
 
          CHECK(
             tree
@@ -200,6 +200,6 @@ SCENARIO("Testing GNDStk Tree operator()") {
             (crossSection,XYs1d)[0]
             (axes,axis).size() == 2
          );
-      }
+      } // WHEN
    }
 }

--- a/src/GNDStk/convert/src/detail.hpp
+++ b/src/GNDStk/convert/src/detail.hpp
@@ -90,8 +90,8 @@ namespace pugi
 }
 */
 
-// internal_xml_node2Node
-inline bool internal_xml_node2Node(const std::string &str)
+// internal_error_xml_node2Node
+inline bool internal_error_xml_node2Node(const std::string &str)
 {
    log::error(
       "Internal error in detail::xml_node2Node(pugi::xml_node,Node):\n"
@@ -132,17 +132,17 @@ bool xml_node2Node(const pugi::xml_node &xnode, NODE &node)
 
       // I don't think that the following should ever appear in this context
       if (xsub.type() == pugi::node_document)
-         return internal_xml_node2Node("node_document");
+         return internal_error_xml_node2Node("node_document");
       if (xsub.type() == pugi::node_declaration)
-         return internal_xml_node2Node("node_declaration");
+         return internal_error_xml_node2Node("node_declaration");
 
       // For now I won't handle these; let's ensure that we don't see them
       if (xsub.type() == pugi::node_null)
-         return internal_xml_node2Node("node_null");
+         return internal_error_xml_node2Node("node_null");
       if (xsub.type() == pugi::node_pi)
-         return internal_xml_node2Node("node_pi");
+         return internal_error_xml_node2Node("node_pi");
       if (xsub.type() == pugi::node_doctype)
-         return internal_xml_node2Node("node_doctype");
+         return internal_error_xml_node2Node("node_doctype");
 
       // ------------------------
       // element (typical case)
@@ -218,7 +218,7 @@ bool xml_node2Node(const pugi::xml_node &xnode, NODE &node)
 // to reformulate all this in a shorter way, but this is what we have for now.
 
 // Helper
-inline bool internal_json2node(const std::string &str)
+inline bool internal_error_json2node(const std::string &str)
 {
    log::error(
       "Internal error in detail::json2node(nlohmann::json,Node):\n"
@@ -235,15 +235,15 @@ bool json2node(const nlohmann::json::const_iterator &iter, NODE &node)
 {
    // the node sent here should be fresh, ready to receive entries...
    if (!node.empty())
-      return internal_json2node("!node.empty()");
+      return internal_error_json2node("!node.empty()");
 
    // non-object cases were handled before a caller calls this function...
    if (!iter->is_object())
-      return internal_json2node("!iter->is_object()");
+      return internal_error_json2node("!iter->is_object()");
 
-   // any "attributes" key should have been handled at the parent level...
+   // any "attributes" key should have been handled in the caller...
    if (iter.key() == "attributes")
-      return internal_json2node("iter.key() == \"attributes\"");
+      return internal_error_json2node("iter.key() == \"attributes\"");
 
    // key,value ==> node name, json value to bring in
    node.name = iter.key();
@@ -277,7 +277,7 @@ bool json2node(const nlohmann::json::const_iterator &iter, NODE &node)
          node.add().name = elem.key();
       } else {
          // no other cases are handled right now
-         return internal_json2node("unhandled JSON value type");
+         return internal_error_json2node("unhandled JSON value type");
       }
    }
 
@@ -288,8 +288,8 @@ bool json2node(const nlohmann::json::const_iterator &iter, NODE &node)
 
 
 // Node ==> Node
-template<class NODEFROM, class NODETO>
-inline void node2Node(const NODEFROM &from, NODETO &to)
+template<class NODE>
+inline void node2Node(const NODE &from, NODE &to)
 {
    // clear
    to.clear();

--- a/src/GNDStk/utility.hpp
+++ b/src/GNDStk/utility.hpp
@@ -7,6 +7,10 @@
 // Number of spaces of indentation you want, in the output of certain types
 inline int indent = 3;
 
+// parents
+// Should Node's debugging output print addresses and parent-node addresses?
+inline bool parents = false;
+
 // decl
 // Should Tree.write() also print the tree's declaration node if it exists?
 inline bool decl = false;


### PR DESCRIPTION
The pointer itself is private; use parent() to get a reference.
The code has some miscellaneous validity check regarding the parent pointer.
Those might be removed at some point; but they probably don't affect speed much.
Small change to json2class.cpp, re: assert() call.
Node's debugging output can optionally print Node's address and parent address.
Removed Tree::nodeType; was left over from de-templatization of Node and Tree.
Minor code tweaks here and there.
More-descriptive names for some detail functions.