### PR TITLE
Resolving an ambiguous name lookup error in python autogenerated code

### DIFF
--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1608,7 +1608,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    cpp << "   // create the component\n";
    cpp << "   python::class_<Component> component(\n";
    cpp << "      module,\n";
-   cpp << "      Component::className(),\n";
+   cpp << "      \"" << clname << "\",\n";
    cpp << "      Component::help().c_str()\n";
    cpp << "   );\n";
    cpp << "\n";

--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1609,7 +1609,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    cpp << "   python::class_<Component> component(\n";
    cpp << "      module,\n";
    cpp << "      Component::className(),\n";
-   cpp << "      Component::help()\n";
+   cpp << "      Component::help().c_str()\n";
    cpp << "   );\n";
    cpp << "\n";
    cpp << "   // wrap the component\n";
@@ -1655,7 +1655,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    for (auto &c : cinfo)
       cpp << "         python::arg(\"" << c.varName << "\"),\n";
 
-   cpp << "         Component::help(\"constructor\")\n";
+   cpp << "         Component::help(\"constructor\").c_str()\n";
    cpp << "      )\n";
 
    // .def_property_readonly...
@@ -1664,7 +1664,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << name << "\",\n";
       cpp << "         &Component::" << name << ",\n";
-      cpp << "         Component::help(\"" << name << "\")\n";
+      cpp << "         Component::help(\"" << name << "\").c_str()\n";
       cpp << "      )\n";
    }
    for (auto &c : cinfo) {
@@ -1672,7 +1672,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << name << "\",\n";
       cpp << "         &Component::" << name << ",\n";
-      cpp << "         Component::help(\"" << name << "\")\n";
+      cpp << "         Component::help(\"" << name << "\").c_str()\n";
       cpp << "      )\n";
    }
 

--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1600,6 +1600,8 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    cpp << "// " << clname << " wrapper\n";
    cpp << "void wrap" << clname << "(python::module &module)\n";
    cpp << "{\n";
+   cpp << "   using namespace njoy::GNDStk;\n";
+   cpp << "\n";
    cpp << "   // type aliases\n";
    cpp << "   using Component = " << "njoy::GNDStk::" << VersionNamespace << "::" << nsname << "::" << clname << ";\n";
    cpp << "\n";

--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1600,10 +1600,8 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    cpp << "// " << clname << " wrapper\n";
    cpp << "void wrap" << clname << "(python::module &module)\n";
    cpp << "{\n";
-   cpp << "   using namespace njoy::GNDStk;\n";
-   cpp << "\n";
    cpp << "   // type aliases\n";
-   cpp << "   using Component = " << VersionNamespace << "::" << nsname << "::" << clname << ";\n";
+   cpp << "   using Component = " << "njoy::GNDStk::" << VersionNamespace << "::" << nsname << "::" << clname << ";\n";
    cpp << "\n";
    cpp << "   // create the component\n";
    cpp << "   python::class_<Component> component(\n";

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -26,7 +26,7 @@ void wrapAxes(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Axes",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // Axes wrapper
 void wrapAxes(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::Axes;
+   using Component = njoy::GNDStk::v1_9::containers::Axes;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -27,7 +27,7 @@ void wrapAxes(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -41,22 +41,22 @@ void wrapAxes(python::module &module)
          python::arg("href"),
          python::arg("axis"),
          python::arg("grid"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "href",
          &Component::href,
-         Component::help("href")
+         Component::help("href").c_str()
       )
       .def_property_readonly(
          "axis",
          &Component::axis,
-         Component::help("axis")
+         Component::help("axis").c_str()
       )
       .def_property_readonly(
          "grid",
          &Component::grid,
-         Component::help("grid")
+         Component::help("grid").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // Axes wrapper
 void wrapAxes(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::Axes;
 

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // Axis wrapper
 void wrapAxis(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::Axis;
+   using Component = njoy::GNDStk::v1_9::containers::Axis;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -26,7 +26,7 @@ void wrapAxis(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Axis",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // Axis wrapper
 void wrapAxis(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::Axis;
 

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -27,7 +27,7 @@ void wrapAxis(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -41,22 +41,22 @@ void wrapAxis(python::module &module)
          python::arg("index"),
          python::arg("label"),
          python::arg("unit"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::help("index")
+         Component::help("index").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label")
+         Component::help("label").c_str()
       )
       .def_property_readonly(
          "unit",
          &Component::unit,
-         Component::help("unit")
+         Component::help("unit").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // Grid wrapper
 void wrapGrid(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::Grid;
+   using Component = njoy::GNDStk::v1_9::containers::Grid;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -27,7 +27,7 @@ void wrapGrid(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -51,47 +51,47 @@ void wrapGrid(python::module &module)
          python::arg("link"),
          python::arg("values"),
          python::arg("choice"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::help("index")
+         Component::help("index").c_str()
       )
       .def_property_readonly(
          "interpolation",
          &Component::interpolation,
-         Component::help("interpolation")
+         Component::help("interpolation").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label")
+         Component::help("label").c_str()
       )
       .def_property_readonly(
          "style",
          &Component::style,
-         Component::help("style")
+         Component::help("style").c_str()
       )
       .def_property_readonly(
          "unit",
          &Component::unit,
-         Component::help("unit")
+         Component::help("unit").c_str()
       )
       .def_property_readonly(
          "link",
          &Component::link,
-         Component::help("link")
+         Component::help("link").c_str()
       )
       .def_property_readonly(
          "values",
          &Component::values,
-         Component::help("values")
+         Component::help("values").c_str()
       )
       .def_property_readonly(
          "choice",
          &Component::choice,
-         Component::help("choice")
+         Component::help("choice").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // Grid wrapper
 void wrapGrid(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::Grid;
 

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -26,7 +26,7 @@ void wrapGrid(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Grid",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // Link wrapper
 void wrapLink(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::Link;
 

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // Link wrapper
 void wrapLink(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::Link;
+   using Component = njoy::GNDStk::v1_9::containers::Link;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -27,7 +27,7 @@ void wrapLink(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -37,12 +37,12 @@ void wrapLink(python::module &module)
             const std::optional<bodyText> &
          >(),
          python::arg("href"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "href",
          &Component::href,
-         Component::help("href")
+         Component::help("href").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -26,7 +26,7 @@ void wrapLink(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Link",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // Regions1d wrapper
 void wrapRegions1d(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::Regions1d;
+   using Component = njoy::GNDStk::v1_9::containers::Regions1d;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // Regions1d wrapper
 void wrapRegions1d(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::Regions1d;
 

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -27,7 +27,7 @@ void wrapRegions1d(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -43,27 +43,27 @@ void wrapRegions1d(python::module &module)
          python::arg("outerDomainValue"),
          python::arg("XYs1d"),
          python::arg("axes"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label")
+         Component::help("label").c_str()
       )
       .def_property_readonly(
          "outerDomainValue",
          &Component::outerDomainValue,
-         Component::help("outerDomainValue")
+         Component::help("outerDomainValue").c_str()
       )
       .def_property_readonly(
          "XYs1d",
          &Component::XYs1d,
-         Component::help("XYs1d")
+         Component::help("XYs1d").c_str()
       )
       .def_property_readonly(
          "axes",
          &Component::axes,
-         Component::help("axes")
+         Component::help("axes").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -26,7 +26,7 @@ void wrapRegions1d(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Regions1d",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -27,7 +27,7 @@ void wrapValues(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -41,22 +41,22 @@ void wrapValues(python::module &module)
          python::arg("length"),
          python::arg("start"),
          python::arg("valueType"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "length",
          &Component::length,
-         Component::help("length")
+         Component::help("length").c_str()
       )
       .def_property_readonly(
          "start",
          &Component::start,
-         Component::help("start")
+         Component::help("start").c_str()
       )
       .def_property_readonly(
          "valueType",
          &Component::valueType,
-         Component::help("valueType")
+         Component::help("valueType").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -26,7 +26,7 @@ void wrapValues(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Values",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // Values wrapper
 void wrapValues(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::Values;
 

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // Values wrapper
 void wrapValues(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::Values;
+   using Component = njoy::GNDStk::v1_9::containers::Values;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -27,7 +27,7 @@ void wrapXYs1d(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -47,37 +47,37 @@ void wrapXYs1d(python::module &module)
          python::arg("outerDomainValue"),
          python::arg("axes"),
          python::arg("values"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::help("index")
+         Component::help("index").c_str()
       )
       .def_property_readonly(
          "interpolation",
          &Component::interpolation,
-         Component::help("interpolation")
+         Component::help("interpolation").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label")
+         Component::help("label").c_str()
       )
       .def_property_readonly(
          "outerDomainValue",
          &Component::outerDomainValue,
-         Component::help("outerDomainValue")
+         Component::help("outerDomainValue").c_str()
       )
       .def_property_readonly(
          "axes",
          &Component::axes,
-         Component::help("axes")
+         Component::help("axes").c_str()
       )
       .def_property_readonly(
          "values",
          &Component::values,
-         Component::help("values")
+         Component::help("values").c_str()
       )
    ;
 }

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -26,7 +26,7 @@ void wrapXYs1d(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "XYs1d",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -18,6 +18,8 @@ namespace containers {
 // XYs1d wrapper
 void wrapXYs1d(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::containers::XYs1d;
 

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -18,10 +18,8 @@ namespace containers {
 // XYs1d wrapper
 void wrapXYs1d(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::containers::XYs1d;
+   using Component = njoy::GNDStk::v1_9::containers::XYs1d;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -27,7 +27,7 @@ void wrapCrossSection(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -41,22 +41,22 @@ void wrapCrossSection(python::module &module)
          python::arg("XYs1d"),
          python::arg("regions1d"),
          python::arg("choice"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "XYs1d",
          &Component::XYs1d,
-         Component::help("XYs1d")
+         Component::help("XYs1d").c_str()
       )
       .def_property_readonly(
          "regions1d",
          &Component::regions1d,
-         Component::help("regions1d")
+         Component::help("regions1d").c_str()
       )
       .def_property_readonly(
          "choice",
          &Component::choice,
-         Component::help("choice")
+         Component::help("choice").c_str()
       )
    ;
 }

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -18,6 +18,8 @@ namespace transport {
 // CrossSection wrapper
 void wrapCrossSection(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::transport::CrossSection;
 

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -18,10 +18,8 @@ namespace transport {
 // CrossSection wrapper
 void wrapCrossSection(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::transport::CrossSection;
+   using Component = njoy::GNDStk::v1_9::transport::CrossSection;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -26,7 +26,7 @@ void wrapCrossSection(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "CrossSection",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -26,7 +26,7 @@ void wrapReaction(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Reaction",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -27,7 +27,7 @@ void wrapReaction(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -43,27 +43,27 @@ void wrapReaction(python::module &module)
          python::arg("fissionGenre"),
          python::arg("label"),
          python::arg("crossSection"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "ENDF_MT",
          &Component::ENDF_MT,
-         Component::help("ENDF_MT")
+         Component::help("ENDF_MT").c_str()
       )
       .def_property_readonly(
          "fissionGenre",
          &Component::fissionGenre,
-         Component::help("fissionGenre")
+         Component::help("fissionGenre").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label")
+         Component::help("label").c_str()
       )
       .def_property_readonly(
          "crossSection",
          &Component::crossSection,
-         Component::help("crossSection")
+         Component::help("crossSection").c_str()
       )
    ;
 }

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -18,10 +18,8 @@ namespace transport {
 // Reaction wrapper
 void wrapReaction(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::transport::Reaction;
+   using Component = njoy::GNDStk::v1_9::transport::Reaction;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -18,6 +18,8 @@ namespace transport {
 // Reaction wrapper
 void wrapReaction(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::transport::Reaction;
 

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -18,10 +18,8 @@ namespace transport {
 // ReactionSuite wrapper
 void wrapReactionSuite(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::transport::ReactionSuite;
+   using Component = njoy::GNDStk::v1_9::transport::ReactionSuite;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -27,7 +27,7 @@ void wrapReactionSuite(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -49,42 +49,42 @@ void wrapReactionSuite(python::module &module)
          python::arg("projectileFrame"),
          python::arg("target"),
          python::arg("reactions"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "evaluation",
          &Component::evaluation,
-         Component::help("evaluation")
+         Component::help("evaluation").c_str()
       )
       .def_property_readonly(
          "format",
          &Component::format,
-         Component::help("format")
+         Component::help("format").c_str()
       )
       .def_property_readonly(
          "interaction",
          &Component::interaction,
-         Component::help("interaction")
+         Component::help("interaction").c_str()
       )
       .def_property_readonly(
          "projectile",
          &Component::projectile,
-         Component::help("projectile")
+         Component::help("projectile").c_str()
       )
       .def_property_readonly(
          "projectileFrame",
          &Component::projectileFrame,
-         Component::help("projectileFrame")
+         Component::help("projectileFrame").c_str()
       )
       .def_property_readonly(
          "target",
          &Component::target,
-         Component::help("target")
+         Component::help("target").c_str()
       )
       .def_property_readonly(
          "reactions",
          &Component::reactions,
-         Component::help("reactions")
+         Component::help("reactions").c_str()
       )
    ;
 }

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -26,7 +26,7 @@ void wrapReactionSuite(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "ReactionSuite",
       Component::help().c_str()
    );
 

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -18,6 +18,8 @@ namespace transport {
 // ReactionSuite wrapper
 void wrapReactionSuite(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::transport::ReactionSuite;
 

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -18,6 +18,8 @@ namespace transport {
 // Reactions wrapper
 void wrapReactions(python::module &module)
 {
+   using namespace njoy::GNDStk;
+
    // type aliases
    using Component = njoy::GNDStk::v1_9::transport::Reactions;
 

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -18,10 +18,8 @@ namespace transport {
 // Reactions wrapper
 void wrapReactions(python::module &module)
 {
-   using namespace njoy::GNDStk;
-
    // type aliases
-   using Component = v1_9::transport::Reactions;
+   using Component = njoy::GNDStk::v1_9::transport::Reactions;
 
    // create the component
    python::class_<Component> component(

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -27,7 +27,7 @@ void wrapReactions(python::module &module)
    python::class_<Component> component(
       module,
       Component::className(),
-      Component::help()
+      Component::help().c_str()
    );
 
    // wrap the component
@@ -37,12 +37,12 @@ void wrapReactions(python::module &module)
             const std::vector<transport::Reaction> &
          >(),
          python::arg("reaction"),
-         Component::help("constructor")
+         Component::help("constructor").c_str()
       )
       .def_property_readonly(
          "reaction",
          &Component::reaction,
-         Component::help("reaction")
+         Component::help("reaction").c_str()
       )
    ;
 }

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -26,7 +26,7 @@ void wrapReactions(python::module &module)
    // create the component
    python::class_<Component> component(
       module,
-      Component::className(),
+      "Reactions",
       Component::help().c_str()
    );
 


### PR DESCRIPTION
When trying to compile the python bindings, the "using njoy::GNDStk;" causes an ambiguous name lookup error for the Component aliasing. Fully specifying the namespace (and removing the using statements) resolves the error.

The generated python wrapper cpp files were updated as well.