### PR TITLE
In JSON, changed "link" "type" to "UTF8Text", not "bodyText".

### DIFF
--- a/autogen/generalPurpose.json
+++ b/autogen/generalPurpose.json
@@ -11,7 +11,7 @@
                 "description": "The URL or xpath-like string pointing to the referred-to element",
                 "name": "href",
                 "required": false,
-                "type": "bodyText"
+                "type": "UTF8Text"
             }
         },
         "bodyText": null,

--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1478,7 +1478,8 @@ void make_class(
    oss << "\n   using BaseComponent = Component<"
        << clname << (hasBodyText ? ",true" : "") << ">;";
    oss << "\n   using BaseBodyText = BodyText<"
-       <<           (hasBodyText ?  "true" : "false") << ">;\n";
+       <<           (hasBodyText ?  "true" : "false") << ">;";
+   oss << "\n   using BaseComponent::construct;\n";
 
    // output: defaults (applicable only to metadata)
    oss << "\n   " << small;
@@ -1662,7 +1663,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    cpp << "   python::class_<Component> component(\n";
    cpp << "      module,\n";
    cpp << "      \"" << clname << "\",\n";
-   cpp << "      Component::help().c_str()\n";
+   cpp << "      Component::documentation().c_str()\n";
    cpp << "   );\n";
    cpp << "\n";
    cpp << "   // wrap the component\n";
@@ -1739,7 +1740,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    if (hasBodyText) {
       cpp << "         python::arg(\"values\"),\n";
    }
-   cpp << "         Component::help(\"constructor\").c_str()\n";
+   cpp << "         Component::documentation(\"constructor\").c_str()\n";
    cpp << "      )\n";
 
    // .def_property_readonly...
@@ -1748,7 +1749,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << pythonname << "\",\n";
       cpp << "         &Component::" << m.varName << ",\n";
-      cpp << "         Component::help(\"" << pythonname << "\").c_str()\n";
+      cpp << "         Component::documentation(\"" << pythonname << "\").c_str()\n";
       cpp << "      )\n";
    }
    for (auto &c : cinfo) {
@@ -1756,7 +1757,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << pythonname << "\",\n";
       cpp << "         &Component::" << c.varName << ",\n";
-      cpp << "         Component::help(\"" << pythonname << "\").c_str()\n";
+      cpp << "         Component::documentation(\"" << pythonname << "\").c_str()\n";
       cpp << "      )\n";
    }
 
@@ -1765,7 +1766,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "         \"" << bodyName << "\",\n";
       cpp << "         [] (const Component &self) "
           << "{ return self." << bodyName << "(); },\n";
-      cpp << "         Component::help(\"" << bodyName << "\").c_str()\n";
+      cpp << "         Component::documentation(\"" << bodyName << "\").c_str()\n";
       cpp << "      )\n";
    }
 

--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -123,9 +123,8 @@ const std::map<std::string,std::string> mapMetaDefault {
 std::string replace(std::string str, const char from, const char to)
 {
    for (auto i = str.size(); i--; ) {
-
-     if (str[i] == from)
-        str[i] = to;
+      if (str[i] == from)
+         str[i] = to;
    }
    return str;
 }
@@ -133,8 +132,7 @@ std::string replace(std::string str, const char from, const char to)
 std::string uppercase(std::string str)
 {
    for (auto i = str.size(); i--; ) {
-
-     str[i] = toupper(str[i]);
+      str[i] = toupper(str[i]);
    }
    return str;
 }
@@ -217,8 +215,7 @@ void insertNDep(
       const auto ndep = *iter;
       sourceVec.erase(iter);
       for (const auto &name : ndep.dependencies) {
-
-        insertNDep(name, sourceVec, targetVec);
+         insertNDep(name, sourceVec, targetVec);
       }
       targetVec.push_back(ndep);
    }
@@ -238,8 +235,7 @@ void printDepVec(
       if (ndep.dependencies.size() > 0)
          std::cout << ":";
       for (const auto &dep : ndep.dependencies) {
-
-        std::cout << " " << dep.first << "::" << dep.second;
+         std::cout << " " << dep.first << "::" << dep.second;
       }
       std::cout << std::endl;
    }
@@ -617,9 +613,8 @@ void compute_children(
             // current one, or we consider this situation to be ambiguous
             for (auto it = class2nspace.equal_range(varType).first;
                  it != class2nspace.equal_range(varType).second; ++it) {
-
-              if (it->second == file_namespace) // current namespace...
-                ns = file_namespace; // ...is presumed; good news
+               if (it->second == file_namespace) // current namespace...
+                  ns = file_namespace; // ...is presumed; good news
             }
 
             if (ns == "") { // none of the >= 2 are in current namespace :-(
@@ -627,8 +622,7 @@ void compute_children(
                int count = 0;
                for (auto it = class2nspace.equal_range(varType).first;
                     it != class2nspace.equal_range(varType).second; ++it) {
-
-                 warn << (count++ ? ", " : "") << it->second;
+                  warn << (count++ ? ", " : "") << it->second;
                }
                log::warning(
                   "{}::{} has child of ambiguous type {}.\n"
@@ -686,24 +680,23 @@ void compute_children(
    }
 
    for (const auto &c : vecInfoChildren) {
+      if (c.isChoice) {
+         vecInfoChildren.push_back(infoChildren{});
 
-     if (c.isChoice) {
-        vecInfoChildren.push_back(infoChildren{});
-
-        vecInfoChildren.back().varName     = "choice";
-        vecInfoChildren.back().varType     = "VARIANT";
-        vecInfoChildren.back().fullVarType = c.isVector
-           ? "std::vector<VARIANT>"
-           : "VARIANT";
-        vecInfoChildren.back().halfVarType = "VARIANT";
-        vecInfoChildren.back().isOptional  = false;
-        vecInfoChildren.back().isVector    = c.isVector;
-        vecInfoChildren.back().isChoice    = false; // for choice itself
-        vecInfoChildren.back().varNameSeq  = names;
-        ossc << "      " << vecInfoChildren.back().fullVarType << " "
-             << vecInfoChildren.back().varName << ";\n";
-        break;
-     }
+         vecInfoChildren.back().varName     = "choice";
+         vecInfoChildren.back().varType     = "VARIANT";
+         vecInfoChildren.back().fullVarType = c.isVector
+            ? "std::vector<VARIANT>"
+            : "VARIANT";
+         vecInfoChildren.back().halfVarType = "VARIANT";
+         vecInfoChildren.back().isOptional  = false;
+         vecInfoChildren.back().isVector    = c.isVector;
+         vecInfoChildren.back().isChoice    = false; // for choice itself
+         vecInfoChildren.back().varNameSeq  = names;
+         ossc << "      " << vecInfoChildren.back().fullVarType << " "
+              << vecInfoChildren.back().varName << ";\n";
+         break;
+      }
    }
 } // compute_children
 
@@ -724,16 +717,16 @@ void write_keys(
 ) {
    // using VARIANT = ..., if necessary
    for (const auto &child : vecInfoChildren) {
-
-     if (child.isChoice) {
-        os << "\n   using VARIANT = std::variant<";
-        std::size_t count = 0;
-        for (const auto &c : vecInfoChildren)
-           if (c.isChoice)
-              os << (count++ ? "," : "") << "\n      " << c.varType;
-        os << "\n   >;\n";
-        break;
-     }
+      if (child.isChoice) {
+         os << "\n   using VARIANT = std::variant<";
+         std::size_t count = 0;
+         for (const auto &c : vecInfoChildren) {
+            if (c.isChoice)
+               os << (count++ ? "," : "") << "\n      " << c.varType;
+         }
+         os << "\n   >;\n";
+         break;
+      }
    }
 
    // names
@@ -766,10 +759,9 @@ void write_keys(
       // metadata
       std::size_t count = 0;
       for (const auto &m : vecInfoMetadata) {
-
-        os << (count++ ? " |\n" : "\n         // metadata\n")
-           << "         " << m.fullVarType << "{" << m.theDefault << "}\n"
-           << "            / Meta<>(\""  << m.varName << "\")";
+         os << (count++ ? " |\n" : "\n         // metadata\n")
+            << "         " << m.fullVarType << "{" << m.theDefault << "}\n"
+            << "            / Meta<>(\""  << m.varName << "\")";
       }
 
       // children
@@ -777,12 +769,11 @@ void write_keys(
          os << " |";
       count = 0;
       for (const auto &c : vecInfoChildren) {
-
-        if (!c.isChoice)
-           os << (count++ ? " |\n" : "\n         // children\n")
-              << "         " << c.halfVarType << "{}\n" // w/o any std::vector<>
-              << "            / " << (c.isVector ? "++" : "--") << "Child<>(\""
-              << (c.varNameSeq == "" ? c.varName : c.varNameSeq) << "\")";
+         if (!c.isChoice)
+            os << (count++ ? " |\n" : "\n         // children\n")
+               << "         " << c.halfVarType << "{}\n" // w/o any std::vector<>
+               << "            / " << (c.isVector ? "++" : "--") << "Child<>(\""
+               << (c.varNameSeq == "" ? c.varName : c.varNameSeq) << "\")";
       }
       os << "\n      ;\n";
    }
@@ -1058,11 +1049,9 @@ void write_component_base(
       : os << "         BaseBodyText{}";
 
    for (const auto &m : vecInfoMetadata) { // metadata
-
       os << ",\n         content." + m.varName;
    }
    for (const auto &c : vecInfoChildren) { // children
-
      if (!c.isChoice)
         os << ",\n         content." + c.varName;
    }
@@ -1174,15 +1163,13 @@ void write_class_ctor(
    count = 0;
    os << "   explicit " << clname << "(";
    for (const auto &m : vecInfoMetadata) {
-
-     os << (count++ ? ",\n" : "\n")
-        << "      const " << m.fullVarType << " &" << m.varName;
+      os << (count++ ? ",\n" : "\n")
+         << "      const " << m.fullVarType << " &" << m.varName;
    }
    for (const auto &c : vecInfoChildren) {
-
-     if (!c.isChoice)
-        os << (count++ ? ",\n" : "\n")
-           << "      const " << c.fullVarType << " &" << c.varName;
+      if (!c.isChoice)
+         os << (count++ ? ",\n" : "\n")
+            << "      const " << c.fullVarType << " &" << c.varName;
    }
    os << "\n   ) :\n";
    write_component_base(os, vecInfoMetadata, vecInfoChildren, false);
@@ -1192,13 +1179,11 @@ void write_class_ctor(
    os << "      content{";
    count = 0;
    for (const auto &m : vecInfoMetadata) {
-
-     os << (count++ ? ",\n" : "\n") << "         " << m.varName;
+      os << (count++ ? ",\n" : "\n") << "         " << m.varName;
    }
    for (const auto &c : vecInfoChildren) {
-
-     if (!c.isChoice)
-        os << (count++ ? ",\n" : "\n") << "         " << c.varName;
+      if (!c.isChoice)
+         os << (count++ ? ",\n" : "\n") << "         " << c.varName;
    }
    os << "\n      }\n";
 
@@ -1213,9 +1198,8 @@ void write_class_ctor(
 
    bool def = false; // are there any Defaulted<>s?
    for (const auto &m : vecInfoMetadata) {
-
-     if (m.isDefaulted)
-        def = true;
+      if (m.isDefaulted)
+         def = true;
    }
    // infoChildren doesn't have isDefaulted, so isn't a factor here
    if (!def)
@@ -1226,15 +1210,13 @@ void write_class_ctor(
    count = 0;
    os << "   explicit " << clname << "(";
    for (const auto &m : vecInfoMetadata) {
-
-     os << (count++ ? ",\n" : "\n") << "      const "
-        << (m.isDefaulted ? m.varType : m.fullVarType) << " &" << m.varName;
+      os << (count++ ? ",\n" : "\n") << "      const "
+         << (m.isDefaulted ? m.varType : m.fullVarType) << " &" << m.varName;
    }
    for (const auto &c : vecInfoChildren) {
-
-     if (!c.isChoice)
-        os << (count++ ? ",\n" : "\n") << "      const "
-           << c.fullVarType << " &" << c.varName;
+      if (!c.isChoice)
+         os << (count++ ? ",\n" : "\n") << "      const "
+            << c.fullVarType << " &" << c.varName;
    }
    os << "\n   ) :\n";
    write_component_base(os, vecInfoMetadata, vecInfoChildren, false);
@@ -1244,21 +1226,19 @@ void write_class_ctor(
    os << "      content{";
    count = 0;
    for (const auto &m : vecInfoMetadata) {
-
-     if (m.isDefaulted)
-        os << (count++ ? ",\n" : "\n") << "         " << m.varName
-           << " == " << m.theDefault << "\n"
-           << "            ? " << m.fullVarType
-           << "{" << m.theDefault << "}\n"
-           << "            : " << m.fullVarType
-           << "{" << m.theDefault << "," << m.varName << "}";
-     else
-        os << (count++ ? ",\n" : "\n") << "         " << m.varName;
+      if (m.isDefaulted)
+         os << (count++ ? ",\n" : "\n") << "         " << m.varName
+            << " == " << m.theDefault << "\n"
+            << "            ? " << m.fullVarType
+            << "{" << m.theDefault << "}\n"
+            << "            : " << m.fullVarType
+            << "{" << m.theDefault << "," << m.varName << "}";
+      else
+         os << (count++ ? ",\n" : "\n") << "         " << m.varName;
    }
    for (const auto &c : vecInfoChildren) {
-
-     if (!c.isChoice)
-        os << (count++ ? ",\n" : "\n") << "         " << c.varName;
+      if (!c.isChoice)
+         os << (count++ ? ",\n" : "\n") << "         " << c.varName;
    }
    os << "\n      }\n";
 
@@ -1295,7 +1275,6 @@ std::map<std::string,NSFile> namespace2file;
 
 // namespace,class names to file names (GNDStk HPP and Python CPP for the class)
 std::map<std::pair<std::string,std::string>,CLFile> class2files;
-
 
 // make_forward
 void make_forward(
@@ -1414,6 +1393,14 @@ std::map<
    >
 > class2info;
 
+// Keep track of whether or not the class has BodyText
+std::map<
+   std::pair<
+      std::string, // namespace::
+      std::string  // class
+   >,
+   bool // has BodyText?
+> class2bodytext;
 
 
 // make_class
@@ -1472,6 +1459,12 @@ void make_class(
          std::make_pair(vecInfoMetadata,vecInfoChildren)
       )
    );
+   class2bodytext.insert(
+      std::make_pair(
+         std::make_pair(file_namespace,clname),
+         hasBodyText
+      )
+   );
 
    // output: names, keys
    // As needed by the Component base
@@ -1495,11 +1488,10 @@ void make_class(
    oss << "\n";
    oss << "\n   static const struct {\n";
    for (auto &m : vecInfoMetadata) {
-
-     if (m.isDefaulted) {
-        oss << "      const " << m.varType << " " << m.varName;
-        oss << "{" << m.theDefault << "};\n";
-     }
+      if (m.isDefaulted) {
+         oss << "      const " << m.varType << " " << m.varName;
+         oss << "{" << m.theDefault << "};\n";
+      }
    }
    oss << "   } defaults;\n";
 
@@ -1583,9 +1575,8 @@ void file_python_namespace(
    cpp << "// " << nsname << " declarations\n";
    cpp << "namespace " << nsname << " {\n";
    for (auto &cl : sortedClassDependencies) {
-
-     if (cl.name.first == nsname)
-        cpp << "   void wrap" << cl.name.second << "(python::module &);\n";
+      if (cl.name.first == nsname)
+         cpp << "   void wrap" << cl.name.second << "(python::module &);\n";
    }
    cpp << "} // namespace " << nsname << "\n";
    cpp << "\n";
@@ -1601,10 +1592,9 @@ void file_python_namespace(
 
    cpp << "\n   // wrap " << nsname << " components\n";
    for (auto &cl : sortedClassDependencies) {
-
-     if (cl.name.first == nsname)
-        cpp << "   " << nsname << "::wrap" << cl.name.second
-            << "(submodule);\n";
+      if (cl.name.first == nsname)
+         cpp << "   " << nsname << "::wrap" << cl.name.second
+             << "(submodule);\n";
    }
    cpp << "};\n";
 
@@ -1617,19 +1607,18 @@ void file_python_namespace(
 // file_python_class
 // -----------------------------------------------------------------------------
 
-std::string toPythonName( const std::string& name ) {
-
-  std::string python;
-  python += std::tolower( name[0] );
-  for ( auto iter = name.begin() + 1; iter != name.end(); ++iter ) {
-
-    if ( std::isupper( *iter ) && std::islower( *( iter - 1 ) ) ) {
-
-      python += '_';
-    }
-    python += std::tolower( *iter );
-  }
-  return python;
+std::string toPythonName(const std::string &name)
+{
+   assert(name != "");
+   std::string python;
+   python += std::tolower(name[0]);
+   for ( auto iter = name.begin() + 1; iter != name.end(); ++iter ) {
+      if ( std::isupper(*iter) && std::islower(*(iter-1))) {
+         python += '_';
+      }
+      python += std::tolower(*iter);
+   }
+   return python;
 }
 
 void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
@@ -1684,69 +1673,99 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    assert(info != class2info.end());
    const auto &minfo = info->second.first;  // vector<infoMetadata>
    const auto &cinfo = info->second.second; // vector<infoChildren>
-   const auto total = minfo.size() + cinfo.size();
+
+   // compute some things with respect to "body text"
+   const auto body = class2bodytext.find(obj.name);
+   assert(body != class2bodytext.end());
+   const bool hasBodyText = body->second; // this class has it?
+
+   std::string bodyType = "unknownType";
+   std::string bodyName = "unknownName";
+   if (hasBodyText) {
+      for (auto &m : minfo) {
+         if (m.varName == "valueType") {
+            if (m.theDefault == "\"Integer32\"") {
+               bodyType = "Integer32";
+               bodyName = "ints";
+            }
+            if (m.theDefault == "\"Float64\"") {
+               bodyType = "Float64";
+               bodyName = "doubles";
+            }
+            if (m.theDefault == "\"UTF8Text\"") {
+               bodyType = "UTF8Text";
+               bodyName = "strings";
+            }
+         }
+      }
+   }
+
    std::size_t count;
 
    // python::init<...>
-   cpp << "         python::init<\n";
+   cpp << "         python::init<";
    count = 0;
    for (auto &m : minfo) {
-      cpp << "            const " << (m.isDefaulted ? m.varType : m.fullVarType);
-      cpp << (++count < total ? " &,\n" : " &\n");
+      cpp << (count++ ? "," : "") << "\n            "
+          << "const " << (m.isDefaulted ? m.varType : m.fullVarType) << " &";
    }
    for (auto &c : cinfo) {
-      cpp << "            const " << c.fullVarType;
-      cpp << (++count < total ? " &,\n" : " &\n");
+      cpp << (count++ ? "," : "") << "\n            "
+          << "const " << c.fullVarType << " &";
    }
-   cpp << "         >(),\n";
+   if (hasBodyText) {
+      cpp << (count++ ? "," : "") << "\n            ";
+      cpp << "const std::vector<" << bodyType << "> &";
+   }
+   cpp << "\n         >(),\n";
 
    // python::arg...
    for (auto &m : minfo) {
-
-     cpp << "         python::arg(\"" << toPythonName( m.varName ) << "\")";
-     if (m.isDefaulted) {
-
-        cpp << " = " << m.theDefault;
-     }
-     else {
-
-       if (m.isOptional) {
-
-          cpp << " = std::nullopt";
-       }
-     }
-     cpp << ",\n";
+      cpp << "         python::arg(\"" << toPythonName(m.varName) << "\")";
+      if (m.isDefaulted) {
+         cpp << " = " << m.theDefault;
+      } else if (m.isOptional) {
+         cpp << " = std::nullopt";
+      }
+      cpp << ",\n";
    }
    for (auto &c : cinfo) {
-
-     cpp << "         python::arg(\"" << toPythonName( c.varName ) << "\")";
-     if (c.isOptional) {
-
-        cpp << " = std::nullopt";
-     }
-     cpp << ",\n";
+      cpp << "         python::arg(\"" << toPythonName(c.varName) << "\")";
+      if (c.isOptional) {
+         cpp << " = std::nullopt";
+      }
+      cpp << ",\n";
    }
-
+   if (hasBodyText) {
+      cpp << "         python::arg(\"values\"),\n";
+   }
    cpp << "         Component::help(\"constructor\").c_str()\n";
    cpp << "      )\n";
 
    // .def_property_readonly...
    for (auto &m : minfo) {
-      const auto name = m.varName;
-      const auto pythonname = toPythonName( m.varName );
+      const auto pythonname = toPythonName(m.varName);
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << pythonname << "\",\n";
-      cpp << "         &Component::" << name << ",\n";
+      cpp << "         &Component::" << m.varName << ",\n";
       cpp << "         Component::help(\"" << pythonname << "\").c_str()\n";
       cpp << "      )\n";
    }
    for (auto &c : cinfo) {
-      const auto name = c.varName;
-      const auto pythonname = toPythonName( c.varName );
+      const auto pythonname = toPythonName(c.varName);
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << pythonname << "\",\n";
-      cpp << "         &Component::" << name << ",\n";
+      cpp << "         &Component::" << c.varName << ",\n";
       cpp << "         Component::help(\"" << pythonname << "\").c_str()\n";
+      cpp << "      )\n";
+   }
+
+   if (hasBodyText) {
+      cpp << "      .def_property_readonly(\n";
+      cpp << "         \"" << bodyName << "\",\n";
+      cpp << "         [] (const Component &self) "
+          << "{ return self." << bodyName << "(); },\n";
+      cpp << "         Component::help(\"" << bodyName << "\").c_str()\n";
       cpp << "      )\n";
    }
 
@@ -1792,8 +1811,7 @@ int main()
       ofs << "\n";
       const std::string nsname = jdoc["__namespace__"];
       for (const auto &item : jdoc.items()) {
-
-        make_forward(ofs, nsname, item.key(), item.value(), class2nspace);
+         make_forward(ofs, nsname, item.key(), item.value(), class2nspace);
       }
    }
    std::ofstream ver(HPPforVersion, std::ofstream::app);
@@ -1803,8 +1821,7 @@ int main()
    // FYI
    if (debugging)
       for (const auto &val : class2nspace) {
-
-        std::cout << val.first << ": " << val.second << std::endl;
+         std::cout << val.first << ": " << val.second << std::endl;
       }
 
    // Print classes into temporary strings, because they have to be reordered
@@ -1814,8 +1831,7 @@ int main()
       read(file,jdoc);
       const std::string file_namespace = jdoc["__namespace__"];
       for (const auto &keyvalue : jdoc.items()) {
-
-        make_class(keyvalue, file_namespace, class2nspace);
+         make_class(keyvalue, file_namespace, class2nspace);
       }
    }
 
@@ -1880,9 +1896,8 @@ int main()
          if (obj.dependencies.size() > 0) {
             hpp << "// " << Version << " dependencies\n";
             for (const auto &dep : obj.dependencies) {
-
-              hpp << "#include \"GNDStk/" << Version << "/"
-                  << dep.first << "/" << dep.second << ".hpp\"\n";
+               hpp << "#include \"GNDStk/" << Version << "/"
+                   << dep.first << "/" << dep.second << ".hpp\"\n";
             }
             hpp << "\n";
          }

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -28,7 +28,7 @@ void wrapAxes(python::module &module)
    python::class_<Component> component(
       module,
       "Axes",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -42,22 +42,22 @@ void wrapAxes(python::module &module)
          python::arg("href") = std::nullopt,
          python::arg("axis") = std::nullopt,
          python::arg("grid") = std::nullopt,
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "href",
          &Component::href,
-         Component::help("href").c_str()
+         Component::documentation("href").c_str()
       )
       .def_property_readonly(
          "axis",
          &Component::axis,
-         Component::help("axis").c_str()
+         Component::documentation("axis").c_str()
       )
       .def_property_readonly(
          "grid",
          &Component::grid,
-         Component::help("grid").c_str()
+         Component::documentation("grid").c_str()
       )
    ;
 

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -28,7 +28,7 @@ void wrapAxis(python::module &module)
    python::class_<Component> component(
       module,
       "Axis",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -42,22 +42,22 @@ void wrapAxis(python::module &module)
          python::arg("index") = std::nullopt,
          python::arg("label") = std::nullopt,
          python::arg("unit") = std::nullopt,
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::help("index").c_str()
+         Component::documentation("index").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label").c_str()
+         Component::documentation("label").c_str()
       )
       .def_property_readonly(
          "unit",
          &Component::unit,
-         Component::help("unit").c_str()
+         Component::documentation("unit").c_str()
       )
    ;
 

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -28,7 +28,7 @@ void wrapGrid(python::module &module)
    python::class_<Component> component(
       module,
       "Grid",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -52,47 +52,47 @@ void wrapGrid(python::module &module)
          python::arg("link") = std::nullopt,
          python::arg("values") = std::nullopt,
          python::arg("choice"),
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::help("index").c_str()
+         Component::documentation("index").c_str()
       )
       .def_property_readonly(
          "interpolation",
          &Component::interpolation,
-         Component::help("interpolation").c_str()
+         Component::documentation("interpolation").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label").c_str()
+         Component::documentation("label").c_str()
       )
       .def_property_readonly(
          "style",
          &Component::style,
-         Component::help("style").c_str()
+         Component::documentation("style").c_str()
       )
       .def_property_readonly(
          "unit",
          &Component::unit,
-         Component::help("unit").c_str()
+         Component::documentation("unit").c_str()
       )
       .def_property_readonly(
          "link",
          &Component::link,
-         Component::help("link").c_str()
+         Component::documentation("link").c_str()
       )
       .def_property_readonly(
          "values",
          &Component::values,
-         Component::help("values").c_str()
+         Component::documentation("values").c_str()
       )
       .def_property_readonly(
          "choice",
          &Component::choice,
-         Component::help("choice").c_str()
+         Component::documentation("choice").c_str()
       )
    ;
 

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -28,7 +28,7 @@ void wrapLink(python::module &module)
    python::class_<Component> component(
       module,
       "Link",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -38,12 +38,12 @@ void wrapLink(python::module &module)
             const std::optional<UTF8Text> &
          >(),
          python::arg("href") = std::nullopt,
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "href",
          &Component::href,
-         Component::help("href").c_str()
+         Component::documentation("href").c_str()
       )
    ;
 

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -35,7 +35,7 @@ void wrapLink(python::module &module)
    component
       .def(
          python::init<
-            const std::optional<bodyText> &
+            const std::optional<UTF8Text> &
          >(),
          python::arg("href") = std::nullopt,
          Component::help("constructor").c_str()

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -28,7 +28,7 @@ void wrapRegions1d(python::module &module)
    python::class_<Component> component(
       module,
       "Regions1d",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -44,27 +44,27 @@ void wrapRegions1d(python::module &module)
          python::arg("outer_domain_value") = std::nullopt,
          python::arg("xys1d"),
          python::arg("axes") = std::nullopt,
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label").c_str()
+         Component::documentation("label").c_str()
       )
       .def_property_readonly(
          "outer_domain_value",
          &Component::outerDomainValue,
-         Component::help("outer_domain_value").c_str()
+         Component::documentation("outer_domain_value").c_str()
       )
       .def_property_readonly(
          "xys1d",
          &Component::XYs1d,
-         Component::help("xys1d").c_str()
+         Component::documentation("xys1d").c_str()
       )
       .def_property_readonly(
          "axes",
          &Component::axes,
-         Component::help("axes").c_str()
+         Component::documentation("axes").c_str()
       )
    ;
 

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -28,7 +28,7 @@ void wrapValues(python::module &module)
    python::class_<Component> component(
       module,
       "Values",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -44,27 +44,27 @@ void wrapValues(python::module &module)
          python::arg("start") = 0,
          python::arg("value_type") = "Float64",
          python::arg("values"),
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "length",
          &Component::length,
-         Component::help("length").c_str()
+         Component::documentation("length").c_str()
       )
       .def_property_readonly(
          "start",
          &Component::start,
-         Component::help("start").c_str()
+         Component::documentation("start").c_str()
       )
       .def_property_readonly(
          "value_type",
          &Component::valueType,
-         Component::help("value_type").c_str()
+         Component::documentation("value_type").c_str()
       )
       .def_property_readonly(
          "doubles",
          [] (const Component &self) { return self.doubles(); },
-         Component::help("doubles").c_str()
+         Component::documentation("doubles").c_str()
       )
    ;
 

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -38,7 +38,7 @@ void wrapValues(python::module &module)
             const std::optional<Integer32> &,
             const Integer32 &,
             const UTF8Text &,
-            const std::vector< double >&
+            const std::vector<Float64> &
          >(),
          python::arg("length") = std::nullopt,
          python::arg("start") = 0,
@@ -63,7 +63,7 @@ void wrapValues(python::module &module)
       )
       .def_property_readonly(
          "doubles",
-         [] ( const Component& self ) { return self.doubles(); },
+         [] (const Component &self) { return self.doubles(); },
          Component::help("doubles").c_str()
       )
    ;

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -28,7 +28,7 @@ void wrapXYs1d(python::module &module)
    python::class_<Component> component(
       module,
       "XYs1d",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -48,37 +48,37 @@ void wrapXYs1d(python::module &module)
          python::arg("outer_domain_value") = std::nullopt,
          python::arg("axes") = std::nullopt,
          python::arg("values"),
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::help("index").c_str()
+         Component::documentation("index").c_str()
       )
       .def_property_readonly(
          "interpolation",
          &Component::interpolation,
-         Component::help("interpolation").c_str()
+         Component::documentation("interpolation").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label").c_str()
+         Component::documentation("label").c_str()
       )
       .def_property_readonly(
          "outer_domain_value",
          &Component::outerDomainValue,
-         Component::help("outer_domain_value").c_str()
+         Component::documentation("outer_domain_value").c_str()
       )
       .def_property_readonly(
          "axes",
          &Component::axes,
-         Component::help("axes").c_str()
+         Component::documentation("axes").c_str()
       )
       .def_property_readonly(
          "values",
          &Component::values,
-         Component::help("values").c_str()
+         Component::documentation("values").c_str()
       )
    ;
 

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -28,7 +28,7 @@ void wrapCrossSection(python::module &module)
    python::class_<Component> component(
       module,
       "CrossSection",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -42,22 +42,22 @@ void wrapCrossSection(python::module &module)
          python::arg("xys1d") = std::nullopt,
          python::arg("regions1d") = std::nullopt,
          python::arg("choice"),
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "xys1d",
          &Component::XYs1d,
-         Component::help("xys1d").c_str()
+         Component::documentation("xys1d").c_str()
       )
       .def_property_readonly(
          "regions1d",
          &Component::regions1d,
-         Component::help("regions1d").c_str()
+         Component::documentation("regions1d").c_str()
       )
       .def_property_readonly(
          "choice",
          &Component::choice,
-         Component::help("choice").c_str()
+         Component::documentation("choice").c_str()
       )
    ;
 

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -28,7 +28,7 @@ void wrapReaction(python::module &module)
    python::class_<Component> component(
       module,
       "Reaction",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -44,27 +44,27 @@ void wrapReaction(python::module &module)
          python::arg("fission_genre") = std::nullopt,
          python::arg("label"),
          python::arg("cross_section"),
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "endf_mt",
          &Component::ENDF_MT,
-         Component::help("endf_mt").c_str()
+         Component::documentation("endf_mt").c_str()
       )
       .def_property_readonly(
          "fission_genre",
          &Component::fissionGenre,
-         Component::help("fission_genre").c_str()
+         Component::documentation("fission_genre").c_str()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::help("label").c_str()
+         Component::documentation("label").c_str()
       )
       .def_property_readonly(
          "cross_section",
          &Component::crossSection,
-         Component::help("cross_section").c_str()
+         Component::documentation("cross_section").c_str()
       )
    ;
 

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -28,7 +28,7 @@ void wrapReactionSuite(python::module &module)
    python::class_<Component> component(
       module,
       "ReactionSuite",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -50,42 +50,42 @@ void wrapReactionSuite(python::module &module)
          python::arg("projectile_frame"),
          python::arg("target"),
          python::arg("reactions") = std::nullopt,
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "evaluation",
          &Component::evaluation,
-         Component::help("evaluation").c_str()
+         Component::documentation("evaluation").c_str()
       )
       .def_property_readonly(
          "format",
          &Component::format,
-         Component::help("format").c_str()
+         Component::documentation("format").c_str()
       )
       .def_property_readonly(
          "interaction",
          &Component::interaction,
-         Component::help("interaction").c_str()
+         Component::documentation("interaction").c_str()
       )
       .def_property_readonly(
          "projectile",
          &Component::projectile,
-         Component::help("projectile").c_str()
+         Component::documentation("projectile").c_str()
       )
       .def_property_readonly(
          "projectile_frame",
          &Component::projectileFrame,
-         Component::help("projectile_frame").c_str()
+         Component::documentation("projectile_frame").c_str()
       )
       .def_property_readonly(
          "target",
          &Component::target,
-         Component::help("target").c_str()
+         Component::documentation("target").c_str()
       )
       .def_property_readonly(
          "reactions",
          &Component::reactions,
-         Component::help("reactions").c_str()
+         Component::documentation("reactions").c_str()
       )
    ;
 

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -28,7 +28,7 @@ void wrapReactions(python::module &module)
    python::class_<Component> component(
       module,
       "Reactions",
-      Component::help().c_str()
+      Component::documentation().c_str()
    );
 
    // wrap the component
@@ -38,12 +38,12 @@ void wrapReactions(python::module &module)
             const std::vector<transport::Reaction> &
          >(),
          python::arg("reaction"),
-         Component::help("constructor").c_str()
+         Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
          "reaction",
          &Component::reaction,
-         Component::help("reaction").c_str()
+         Component::documentation("reaction").c_str()
       )
    ;
 

--- a/src/GNDStk/Component.hpp
+++ b/src/GNDStk/Component.hpp
@@ -5,6 +5,10 @@ class Component;
 // general helper constructs
 #include "GNDStk/Component/src/detail.hpp"
 
+// Map from some term/subject to its documentation,
+// for use by classes that derive from Component
+using helpMap = std::map<std::string,std::string>;
+
 
 
 // -----------------------------------------------------------------------------
@@ -43,9 +47,17 @@ class Component : public BodyText<hasBodyText> {
    // construct()
    // Hooks by which derived-class constructors, built by our auto-generation
    // process from JSON-format GNDS specs, can run arbitrary additional code.
-   void construct() const { }
-   void construct(const DERIVED &) const { }
-   void construct(const Node &) const { }
+   void construct()
+   {
+   }
+   void construct(const DERIVED &)
+   {
+      static_cast<DERIVED &>(*this).construct();
+   }
+   void construct(const Node &)
+   {
+      static_cast<DERIVED &>(*this).construct();
+   }
 
    // You can (but don't need to) override in DERIVED
    static std::string namespaceName() { return ""; }
@@ -54,23 +66,24 @@ class Component : public BodyText<hasBodyText> {
    // functions in detail::. These shorten the code in the derived classes.
    #include "GNDStk/Component/src/getter.hpp"
 
+   // Fallback for documentation() if DERIVED doesn't have help
+   static inline helpMap help;
+
 public:
 
    #include "GNDStk/Component/src/fromNode.hpp"
    #include "GNDStk/Component/src/toNode.hpp"
    #include "GNDStk/Component/src/write.hpp"
 
-   // help
-   // Override this function in a derived class in order to provide help,
-   // e.g. for Python bindings, regarding a given subject.
-   static std::string help(const std::string &/*subject*/ = "")
+   // documentation
+   static std::string documentation(const std::string &subject = "")
    {
-      return "No description available";
-      // Suggestion:
-      //    If subject == "", return help for the class
-      //    If subject == "constructor", return help for the constructor
-      //    If subject == "foo", return help for the "foo" parameter
-      // Etc.
+      try {
+         return DERIVED::help.at(subject);
+      }
+      catch ( ... ) {
+         return "No help information is available";
+      }
    }
 
    // Component << std::string

--- a/src/GNDStk/Support.hpp
+++ b/src/GNDStk/Support.hpp
@@ -17,7 +17,6 @@ using Float64 = double;
 // but consider perhaps having specialty types instead
 using UTF8Text = std::string;
 using XMLName  = std::string;
-using bodyText = std::string;
 
 
 

--- a/src/GNDStk/v1.9/containers/Axes.hpp
+++ b/src/GNDStk/v1.9/containers/Axes.hpp
@@ -60,6 +60,7 @@ public:
    // Base classes
    using BaseComponent = Component<Axes>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/containers/Axis.hpp
+++ b/src/GNDStk/v1.9/containers/Axis.hpp
@@ -55,6 +55,7 @@ public:
    // Base classes
    using BaseComponent = Component<Axis>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/containers/Axis/src/custom.hpp
+++ b/src/GNDStk/v1.9/containers/Axis/src/custom.hpp
@@ -1,6 +1,6 @@
 private:
 
-  static inline std::map< std::string, std::string > documentation = {
+  static inline helpMap help = {
 
     { "", "A GNDS 1.9 basic container component: an axis with an index, label and\n"
           "optional unit\n\n"
@@ -16,21 +16,3 @@ private:
     { "label", "The label of the axis component" },
     { "unit", "The unit of the axis component" }
   };
-
-public:
-
-/**
- *  Customise the python binding help documentation
- */
-static std::string help( const std::string& type = "" )
-{
-
-  try {
-
-    return documentation.at( type );
-  }
-  catch ( ... ) {
-
-    return "No help information available";
-  }
-}

--- a/src/GNDStk/v1.9/containers/Grid.hpp
+++ b/src/GNDStk/v1.9/containers/Grid.hpp
@@ -71,6 +71,7 @@ public:
    // Base classes
    using BaseComponent = Component<Grid>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/containers/Link.hpp
+++ b/src/GNDStk/v1.9/containers/Link.hpp
@@ -51,6 +51,7 @@ public:
    // Base classes
    using BaseComponent = Component<Link>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/containers/Link.hpp
+++ b/src/GNDStk/v1.9/containers/Link.hpp
@@ -41,7 +41,7 @@ class Link : public Component<Link> {
    {
       return
          // metadata
-         std::optional<bodyText>{}
+         std::optional<UTF8Text>{}
             / Meta<>("href")
       ;
    }
@@ -66,7 +66,7 @@ public:
 
    struct {
       // metadata
-      std::optional<bodyText> href;
+      std::optional<UTF8Text> href;
    } content;
 
    // ------------------------
@@ -86,7 +86,7 @@ public:
    // ------------------------
 
    // href
-   auto &href(const std::optional<bodyText> &obj)
+   auto &href(const std::optional<UTF8Text> &obj)
     { content.href = obj; return *this; }
 
    // ------------------------
@@ -142,7 +142,7 @@ public:
 
    // from fields
    explicit Link(
-      const std::optional<bodyText> &href
+      const std::optional<UTF8Text> &href
    ) :
       Component{
          BaseBodyText{},

--- a/src/GNDStk/v1.9/containers/Regions1d.hpp
+++ b/src/GNDStk/v1.9/containers/Regions1d.hpp
@@ -62,6 +62,7 @@ public:
    // Base classes
    using BaseComponent = Component<Regions1d>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/containers/Values.hpp
+++ b/src/GNDStk/v1.9/containers/Values.hpp
@@ -55,6 +55,7 @@ public:
    // Base classes
    using BaseComponent = Component<Values,true>;
    using BaseBodyText = BodyText<true>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/containers/Values/src/custom.hpp
+++ b/src/GNDStk/v1.9/containers/Values/src/custom.hpp
@@ -1,6 +1,6 @@
 private:
 
-  static inline std::map< std::string, std::string > documentation = {
+  static inline helpMap help = {
 
     { "", "A GNDS basic component: a list of values\n\n"
           "This component is used in the nodes like XYs1D or the grid node." },
@@ -34,22 +34,6 @@ private:
       log::info( "number values: {}", this->size() );
       throw std::exception();
     }
-  }
-
-  /**
-   *  Custom construct function
-   */
-  void construct( const Values& ) {
-
-    this->construct();
-  }
-
-  /**
-   *  Custom construct function
-   */
-  void construct( const Node& ) {
-
-    this->construct();
   }
 
 public:
@@ -87,19 +71,3 @@ public:
           const Integer32& start = 0,
           const UTF8Text& valueType = "Float64" ) :
     Values( values.size() + start, start, valueType, values ) {}
-
-  /**
-   *  Customise the python binding help documentation
-   */
-  static std::string help( const std::string& type = "" )
-  {
-
-    try {
-
-      return documentation.at( type );
-    }
-    catch ( ... ) {
-
-      return "No help information available";
-    }
-  }

--- a/src/GNDStk/v1.9/containers/XYs1d.hpp
+++ b/src/GNDStk/v1.9/containers/XYs1d.hpp
@@ -66,6 +66,7 @@ public:
    // Base classes
    using BaseComponent = Component<XYs1d>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/transport/CrossSection.hpp
+++ b/src/GNDStk/v1.9/transport/CrossSection.hpp
@@ -60,6 +60,7 @@ public:
    // Base classes
    using BaseComponent = Component<CrossSection>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/transport/Reaction.hpp
+++ b/src/GNDStk/v1.9/transport/Reaction.hpp
@@ -61,6 +61,7 @@ public:
    // Base classes
    using BaseComponent = Component<Reaction>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/transport/ReactionSuite.hpp
+++ b/src/GNDStk/v1.9/transport/ReactionSuite.hpp
@@ -67,6 +67,7 @@ public:
    // Base classes
    using BaseComponent = Component<ReactionSuite>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults

--- a/src/GNDStk/v1.9/transport/Reactions.hpp
+++ b/src/GNDStk/v1.9/transport/Reactions.hpp
@@ -54,6 +54,7 @@ public:
    // Base classes
    using BaseComponent = Component<Reactions>;
    using BaseBodyText = BodyText<false>;
+   using BaseComponent::construct;
 
    // ------------------------
    // Relevant defaults


### PR DESCRIPTION
That really seems better; what we call "body text" refers to something else.
New auto-generated Link.hpp and Link.python.cpp files reflect the above.
Also, no longer needed using bodyText = std::string in Support.hpp.
Which, again, could have created confusion with regards to the term.
Some cosmetic changes in json2class.cpp that I normally wouldn't have done...
...Except that I'm trying to keep some stylistic things consistent.
But I left in the new curly braces!
Importantly (not cosmetic), json2class deals w/body text for Python code.
Didn't quite get to the other things we talked about; those are next.