### PR TITLE
Feature/v1.9 v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,13 @@ pybind11_add_module( GNDStk.python
     python/src/v1.9/containers/Values.python.cpp
     python/src/v1.9/containers/Link.python.cpp
     python/src/v1.9/containers/Grid.python.cpp
+    python/src/v1.9/containers/Axes.python.cpp
+    python/src/v1.9/containers/XYs1d.python.cpp
+    python/src/v1.9/containers/Regions1d.python.cpp
+    python/src/v1.9/transport/CrossSection.python.cpp
+    python/src/v1.9/transport/Reaction.python.cpp
+    python/src/v1.9/transport/Reactions.python.cpp
+    python/src/v1.9/transport/ReactionSuite.python.cpp
     python/src/v1.9/transport.python.cpp
     python/src/v1.9/GNDS.python.cpp
     )

--- a/python/src/GNDStk.python.cpp
+++ b/python/src/GNDStk.python.cpp
@@ -17,7 +17,7 @@ namespace core {
 }
 
 // v1.9 interface declarations
-namespace v1_9 {
+namespace python_v1_9 {
 
   void wrapGNDS( python::module& );
 }
@@ -45,5 +45,5 @@ PYBIND11_MODULE( GNDStk, module ) {
   core::wrapInterpolation( module );
 
   // v1.9 components (in the v1_9 module, created in this function)
-  v1_9::wrapGNDS( module );
+  python_v1_9::wrapGNDS( module );
 }

--- a/python/src/v1.9/GNDS.python.cpp
+++ b/python/src/v1.9/GNDS.python.cpp
@@ -8,13 +8,13 @@
 namespace python = pybind11;
 
 // v1.9 interface declarations
-namespace v1_9 {
+namespace python_v1_9 {
 
   void wrapContainers( python::module& );
   void wrapTransport( python::module& );
 }
 
-namespace v1_9 {
+namespace python_v1_9 {
 
   void wrapGNDS( python::module& module ) {
 
@@ -25,7 +25,7 @@ namespace v1_9 {
       "GNDS 1.9 standard components"
     );
 
-    v1_9::wrapContainers( submodule );
-    v1_9::wrapTransport( submodule );
+    python_v1_9::wrapContainers( submodule );
+    python_v1_9::wrapTransport( submodule );
   }
 } // v1_9 namespace

--- a/python/src/v1.9/containers.python.cpp
+++ b/python/src/v1.9/containers.python.cpp
@@ -8,18 +8,18 @@
 namespace python = pybind11;
 
 // v1.9 interface
-namespace v1_9 {
+namespace python_v1_9 {
 
 // containers declarations
-namespace containers {
+namespace python_containers {
    void wrapAxis(python::module &);
    void wrapLink(python::module &);
    void wrapValues(python::module &);
    void wrapGrid(python::module &);
-   // void wrapAxes(python::module &);
-   // void wrapXYs1d(python::module &);
-   // void wrapRegions1d(python::module &);
-} // namespace containers
+   void wrapAxes(python::module &);
+   void wrapXYs1d(python::module &);
+   void wrapRegions1d(python::module &);
+} // namespace python_containers
 
 // containers wrapper
 void wrapContainers(python::module &module)
@@ -31,13 +31,13 @@ void wrapContainers(python::module &module)
    );
 
    // wrap containers components
-   containers::wrapAxis(submodule);
-   containers::wrapLink(submodule);
-   containers::wrapValues(submodule);
-   containers::wrapGrid(submodule);
-   // containers::wrapAxes(submodule);
-   // containers::wrapXYs1d(submodule);
-   // containers::wrapRegions1d(submodule);
+   python_containers::wrapAxis(submodule);
+   python_containers::wrapLink(submodule);
+   python_containers::wrapValues(submodule);
+   python_containers::wrapGrid(submodule);
+   python_containers::wrapAxes(submodule);
+   python_containers::wrapXYs1d(submodule);
+   python_containers::wrapRegions1d(submodule);
 };
 
-} // namespace v1_9
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -13,19 +13,20 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // Axes wrapper
 void wrapAxes(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::Axes;
+   using Component = containers::Axes;
    using VARIANT = std::variant<
-      njoy::GNDStk::v1_9::containers::Axis,
-      njoy::GNDStk::v1_9::containers::Grid
+      containers::Axis,
+      containers::Grid
    >;
 
    // create the component
@@ -52,18 +53,8 @@ void wrapAxes(python::module &module)
          Component::documentation("href").c_str()
       )
       .def_property_readonly(
-         "axis",
-         &Component::axis,
-         Component::documentation("axis").c_str()
-      )
-      .def_property_readonly(
-         "grid",
-         &Component::grid,
-         Component::documentation("grid").c_str()
-      )
-      .def_property_readonly(
          "choice",
-         &Component::choice,
+         python::overload_cast<>(&Component::choice),
          Component::documentation("choice").c_str()
       )
    ;
@@ -72,5 +63,5 @@ void wrapAxes(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // Axis wrapper
 void wrapAxis(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::Axis;
+   using Component = containers::Axis;
 
    // create the component
    python::class_<Component> component(
@@ -65,5 +66,5 @@ void wrapAxis(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -13,19 +13,20 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // Grid wrapper
 void wrapGrid(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::Grid;
+   using Component = containers::Grid;
    using VARIANT = std::variant<
-      njoy::GNDStk::v1_9::containers::Link,
-      njoy::GNDStk::v1_9::containers::Values
+      containers::Link,
+      containers::Values
    >;
 
    // create the component
@@ -81,17 +82,17 @@ void wrapGrid(python::module &module)
       )
       .def_property_readonly(
          "link",
-         &Component::link,
+         python::overload_cast<>(&Component::link),
          Component::documentation("link").c_str()
       )
       .def_property_readonly(
          "values",
-         &Component::values,
+         python::overload_cast<>(&Component::values),
          Component::documentation("values").c_str()
       )
       .def_property_readonly(
          "choice",
-         &Component::choice,
+         python::overload_cast<>(&Component::choice),
          Component::documentation("choice").c_str()
       )
    ;
@@ -100,5 +101,5 @@ void wrapGrid(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // Link wrapper
 void wrapLink(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::Link;
+   using Component = containers::Link;
 
    // create the component
    python::class_<Component> component(
@@ -51,5 +52,5 @@ void wrapLink(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // Regions1d wrapper
 void wrapRegions1d(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::Regions1d;
+   using Component = containers::Regions1d;
 
    // create the component
    python::class_<Component> component(
@@ -58,12 +59,12 @@ void wrapRegions1d(python::module &module)
       )
       .def_property_readonly(
          "xys1d",
-         &Component::XYs1d,
+         python::overload_cast<>(&Component::XYs1d),
          Component::documentation("xys1d").c_str()
       )
       .def_property_readonly(
          "axes",
-         &Component::axes,
+         python::overload_cast<>(&Component::axes),
          Component::documentation("axes").c_str()
       )
    ;
@@ -72,5 +73,5 @@ void wrapRegions1d(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // Values wrapper
 void wrapValues(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::Values;
+   using Component = containers::Values;
 
    // create the component
    python::class_<Component> component(
@@ -72,5 +73,5 @@ void wrapValues(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace containers {
+namespace python_v1_9 {
+namespace python_containers {
 
 // XYs1d wrapper
 void wrapXYs1d(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::containers::XYs1d;
+   using Component = containers::XYs1d;
 
    // create the component
    python::class_<Component> component(
@@ -72,12 +73,12 @@ void wrapXYs1d(python::module &module)
       )
       .def_property_readonly(
          "axes",
-         &Component::axes,
+         python::overload_cast<>(&Component::axes),
          Component::documentation("axes").c_str()
       )
       .def_property_readonly(
          "values",
-         &Component::values,
+         python::overload_cast<>(&Component::values),
          Component::documentation("values").c_str()
       )
    ;
@@ -86,5 +87,5 @@ void wrapXYs1d(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace containers
-} // namespace v1_9
+} // namespace python_containers
+} // namespace python_v1_9

--- a/python/src/v1.9/transport.python.cpp
+++ b/python/src/v1.9/transport.python.cpp
@@ -8,15 +8,15 @@
 namespace python = pybind11;
 
 // v1.9 interface
-namespace v1_9 {
+namespace python_v1_9 {
 
 // transport declarations
-namespace transport {
-   // void wrapCrossSection(python::module &);
-   // void wrapReaction(python::module &);
-   // void wrapReactions(python::module &);
-   // void wrapReactionSuite(python::module &);
-} // namespace transport
+namespace python_transport {
+   void wrapCrossSection(python::module &);
+   void wrapReaction(python::module &);
+   void wrapReactions(python::module &);
+   void wrapReactionSuite(python::module &);
+} // namespace python_transport
 
 // transport wrapper
 void wrapTransport(python::module &module)
@@ -28,10 +28,10 @@ void wrapTransport(python::module &module)
    );
 
    // wrap transport components
-   // transport::wrapCrossSection(submodule);
-   // transport::wrapReaction(submodule);
-   // transport::wrapReactions(submodule);
-   // transport::wrapReactionSuite(submodule);
+   python_transport::wrapCrossSection(submodule);
+   python_transport::wrapReaction(submodule);
+   python_transport::wrapReactions(submodule);
+   python_transport::wrapReactionSuite(submodule);
 };
 
-} // namespace v1_9
+} // namespace python_v1_9

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -13,19 +13,20 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace transport {
+namespace python_v1_9 {
+namespace python_transport {
 
 // CrossSection wrapper
 void wrapCrossSection(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::transport::CrossSection;
+   using Component = transport::CrossSection;
    using VARIANT = std::variant<
-      njoy::GNDStk::v1_9::containers::XYs1d,
-      njoy::GNDStk::v1_9::containers::Regions1d
+      containers::XYs1d,
+      containers::Regions1d
    >;
 
    // create the component
@@ -45,18 +46,8 @@ void wrapCrossSection(python::module &module)
          Component::documentation("constructor").c_str()
       )
       .def_property_readonly(
-         "xys1d",
-         &Component::XYs1d,
-         Component::documentation("xys1d").c_str()
-      )
-      .def_property_readonly(
-         "regions1d",
-         &Component::regions1d,
-         Component::documentation("regions1d").c_str()
-      )
-      .def_property_readonly(
          "choice",
-         &Component::choice,
+         python::overload_cast<>(&Component::choice),
          Component::documentation("choice").c_str()
       )
    ;
@@ -65,5 +56,5 @@ void wrapCrossSection(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace transport
-} // namespace v1_9
+} // namespace python_transport
+} // namespace python_v1_9

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace transport {
+namespace python_v1_9 {
+namespace python_transport {
 
 // Reaction wrapper
 void wrapReaction(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::transport::Reaction;
+   using Component = transport::Reaction;
 
    // create the component
    python::class_<Component> component(
@@ -63,7 +64,7 @@ void wrapReaction(python::module &module)
       )
       .def_property_readonly(
          "cross_section",
-         &Component::crossSection,
+         python::overload_cast<>(&Component::crossSection),
          Component::documentation("cross_section").c_str()
       )
    ;
@@ -72,5 +73,5 @@ void wrapReaction(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace transport
-} // namespace v1_9
+} // namespace python_transport
+} // namespace python_v1_9

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace transport {
+namespace python_v1_9 {
+namespace python_transport {
 
 // ReactionSuite wrapper
 void wrapReactionSuite(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::transport::ReactionSuite;
+   using Component = transport::ReactionSuite;
 
    // create the component
    python::class_<Component> component(
@@ -84,7 +85,7 @@ void wrapReactionSuite(python::module &module)
       )
       .def_property_readonly(
          "reactions",
-         &Component::reactions,
+         python::overload_cast<>(&Component::reactions),
          Component::documentation("reactions").c_str()
       )
    ;
@@ -93,5 +94,5 @@ void wrapReactionSuite(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace transport
-} // namespace v1_9
+} // namespace python_transport
+} // namespace python_v1_9

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -13,16 +13,17 @@
 // namespace aliases
 namespace python = pybind11;
 
-namespace v1_9 {
-namespace transport {
+namespace python_v1_9 {
+namespace python_transport {
 
 // Reactions wrapper
 void wrapReactions(python::module &module)
 {
    using namespace njoy::GNDStk;
+   using namespace njoy::GNDStk::v1_9;
 
    // type aliases
-   using Component = njoy::GNDStk::v1_9::transport::Reactions;
+   using Component = transport::Reactions;
 
    // create the component
    python::class_<Component> component(
@@ -42,7 +43,7 @@ void wrapReactions(python::module &module)
       )
       .def_property_readonly(
          "reaction",
-         &Component::reaction,
+         python::overload_cast<>(&Component::reaction),
          Component::documentation("reaction").c_str()
       )
    ;
@@ -51,5 +52,5 @@ void wrapReactions(python::module &module)
    addStandardComponentDefinitions< Component >( component );
 }
 
-} // namespace transport
-} // namespace v1_9
+} // namespace python_transport
+} // namespace python_v1_9


### PR DESCRIPTION
A few simple updates:
- restricted python properties based on choice and vector occurrence
- some changes in python bindings namespaces that interfered with proper namespace resolution for types (because the python wrapper functions were in namespaces similar to the component namespaces the compiler could not properly resolve component types)
- all python cpp files are now enabled (no more paying attention to commenting out containers and transport wrapper functions)

In short: the auto-generated python bindings now all compile!

Caveat: not all C++ and python unit tests are done but at least it compiles properly, and all C++ and python unit tests run properly