### PR TITLE
Feature/floating point precision

### DIFF
--- a/autogen/json2class.cpp
+++ b/autogen/json2class.cpp
@@ -1366,10 +1366,10 @@ void make_forward(
       nsdirpy = GNDSDir + "/python/src/" + Version + "/" + file_namespace,
       src     = nsdir + "/" + clname + "/src",
       test    = nsdir + "/" + clname + "/test";
-   system(("mkdir -p " + nsdir  ).c_str());
-   system(("mkdir -p " + nsdirpy).c_str());
-   system(("mkdir -p " + src    ).c_str());
-   system(("mkdir -p " + test   ).c_str());
+   system(("mkdir -p " + nsdir  ).data());
+   system(("mkdir -p " + nsdirpy).data());
+   system(("mkdir -p " + src    ).data());
+   system(("mkdir -p " + test   ).data());
 
    // create custom.hpp, but ONLY if it's not already there
    const std::string custom = src + "/custom.hpp";
@@ -1776,7 +1776,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    cpp << "   python::class_<Component> component(\n";
    cpp << "      module,\n";
    cpp << "      \"" << clname << "\",\n";
-   cpp << "      Component::documentation().c_str()\n";
+   cpp << "      Component::documentation().data()\n";
    cpp << "   );\n";
    cpp << "\n";
    cpp << "   // wrap the component\n";
@@ -1852,7 +1852,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
    if (hasBodyText) {
       cpp << "         python::arg(\"values\"),\n";
    }
-   cpp << "         Component::documentation(\"constructor\").c_str()\n";
+   cpp << "         Component::documentation(\"constructor\").data()\n";
    cpp << "      )\n";
 
    // .def_property_readonly...
@@ -1861,7 +1861,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "      .def_property_readonly(\n";
       cpp << "         \"" << pythonname << "\",\n";
       cpp << "         &Component::" << m.varName << ",\n";
-      cpp << "         Component::documentation(\"" << pythonname << "\").c_str()\n";
+      cpp << "         Component::documentation(\"" << pythonname << "\").data()\n";
       cpp << "      )\n";
    }
    for (auto &c : cinfo) {
@@ -1870,7 +1870,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
          cpp << "      .def_property_readonly(\n";
          cpp << "         \"" << pythonname << "\",\n";
          cpp << "         python::overload_cast<>(&Component::" << c.varName << "),\n";
-         cpp << "         Component::documentation(\"" << pythonname << "\").c_str()\n";
+         cpp << "         Component::documentation(\"" << pythonname << "\").data()\n";
          cpp << "      )\n";
       }
    }
@@ -1880,7 +1880,7 @@ void file_python_class(const NameDeps &obj, const std::string &filePythonCPP)
       cpp << "         \"" << bodyName << "\",\n";
       cpp << "         [] (const Component &self) "
           << "{ return self." << bodyName << "(); },\n";
-      cpp << "         Component::documentation(\"" << bodyName << "\").c_str()\n";
+      cpp << "         Component::documentation(\"" << bodyName << "\").data()\n";
       cpp << "      )\n";
    }
 

--- a/python/src/v1.9/containers/Axes.python.cpp
+++ b/python/src/v1.9/containers/Axes.python.cpp
@@ -33,7 +33,7 @@ void wrapAxes(python::module &module)
    python::class_<Component> component(
       module,
       "Axes",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -45,17 +45,17 @@ void wrapAxes(python::module &module)
          >(),
          python::arg("href") = std::nullopt,
          python::arg("axis_grid"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "href",
          &Component::href,
-         Component::documentation("href").c_str()
+         Component::documentation("href").data()
       )
       .def_property_readonly(
          "axis_grid",
          python::overload_cast<>(&Component::axis_grid),
-         Component::documentation("axis_grid").c_str()
+         Component::documentation("axis_grid").data()
       )
    ;
 

--- a/python/src/v1.9/containers/Axis.python.cpp
+++ b/python/src/v1.9/containers/Axis.python.cpp
@@ -29,7 +29,7 @@ void wrapAxis(python::module &module)
    python::class_<Component> component(
       module,
       "Axis",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -43,22 +43,22 @@ void wrapAxis(python::module &module)
          python::arg("index") = std::nullopt,
          python::arg("label") = std::nullopt,
          python::arg("unit") = std::nullopt,
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::documentation("index").c_str()
+         Component::documentation("index").data()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::documentation("label").c_str()
+         Component::documentation("label").data()
       )
       .def_property_readonly(
          "unit",
          &Component::unit,
-         Component::documentation("unit").c_str()
+         Component::documentation("unit").data()
       )
    ;
 

--- a/python/src/v1.9/containers/Grid.python.cpp
+++ b/python/src/v1.9/containers/Grid.python.cpp
@@ -33,7 +33,7 @@ void wrapGrid(python::module &module)
    python::class_<Component> component(
       module,
       "Grid",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -53,47 +53,47 @@ void wrapGrid(python::module &module)
          python::arg("style") = std::nullopt,
          python::arg("unit") = std::nullopt,
          python::arg("link_values"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::documentation("index").c_str()
+         Component::documentation("index").data()
       )
       .def_property_readonly(
          "interpolation",
          &Component::interpolation,
-         Component::documentation("interpolation").c_str()
+         Component::documentation("interpolation").data()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::documentation("label").c_str()
+         Component::documentation("label").data()
       )
       .def_property_readonly(
          "style",
          &Component::style,
-         Component::documentation("style").c_str()
+         Component::documentation("style").data()
       )
       .def_property_readonly(
          "unit",
          &Component::unit,
-         Component::documentation("unit").c_str()
+         Component::documentation("unit").data()
       )
       .def_property_readonly(
          "link",
          python::overload_cast<>(&Component::link),
-         Component::documentation("link").c_str()
+         Component::documentation("link").data()
       )
       .def_property_readonly(
          "values",
          python::overload_cast<>(&Component::values),
-         Component::documentation("values").c_str()
+         Component::documentation("values").data()
       )
       .def_property_readonly(
          "link_values",
          python::overload_cast<>(&Component::link_values),
-         Component::documentation("link_values").c_str()
+         Component::documentation("link_values").data()
       )
    ;
 

--- a/python/src/v1.9/containers/Link.python.cpp
+++ b/python/src/v1.9/containers/Link.python.cpp
@@ -29,7 +29,7 @@ void wrapLink(python::module &module)
    python::class_<Component> component(
       module,
       "Link",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -39,12 +39,12 @@ void wrapLink(python::module &module)
             const UTF8Text &
          >(),
          python::arg("href"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "href",
          &Component::href,
-         Component::documentation("href").c_str()
+         Component::documentation("href").data()
       )
    ;
 

--- a/python/src/v1.9/containers/Regions1d.python.cpp
+++ b/python/src/v1.9/containers/Regions1d.python.cpp
@@ -29,7 +29,7 @@ void wrapRegions1d(python::module &module)
    python::class_<Component> component(
       module,
       "Regions1d",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -45,27 +45,27 @@ void wrapRegions1d(python::module &module)
          python::arg("outer_domain_value") = std::nullopt,
          python::arg("xys1d"),
          python::arg("axes") = std::nullopt,
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::documentation("label").c_str()
+         Component::documentation("label").data()
       )
       .def_property_readonly(
          "outer_domain_value",
          &Component::outerDomainValue,
-         Component::documentation("outer_domain_value").c_str()
+         Component::documentation("outer_domain_value").data()
       )
       .def_property_readonly(
          "xys1d",
          python::overload_cast<>(&Component::XYs1d),
-         Component::documentation("xys1d").c_str()
+         Component::documentation("xys1d").data()
       )
       .def_property_readonly(
          "axes",
          python::overload_cast<>(&Component::axes),
-         Component::documentation("axes").c_str()
+         Component::documentation("axes").data()
       )
    ;
 

--- a/python/src/v1.9/containers/Values.python.cpp
+++ b/python/src/v1.9/containers/Values.python.cpp
@@ -29,7 +29,7 @@ void wrapValues(python::module &module)
    python::class_<Component> component(
       module,
       "Values",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -45,27 +45,27 @@ void wrapValues(python::module &module)
          python::arg("start") = 0,
          python::arg("value_type") = "Float64",
          python::arg("values"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "length",
          &Component::length,
-         Component::documentation("length").c_str()
+         Component::documentation("length").data()
       )
       .def_property_readonly(
          "start",
          &Component::start,
-         Component::documentation("start").c_str()
+         Component::documentation("start").data()
       )
       .def_property_readonly(
          "value_type",
          &Component::valueType,
-         Component::documentation("value_type").c_str()
+         Component::documentation("value_type").data()
       )
       .def_property_readonly(
          "doubles",
          [] (const Component &self) { return self.doubles(); },
-         Component::documentation("doubles").c_str()
+         Component::documentation("doubles").data()
       )
    ;
 

--- a/python/src/v1.9/containers/XYs1d.python.cpp
+++ b/python/src/v1.9/containers/XYs1d.python.cpp
@@ -29,7 +29,7 @@ void wrapXYs1d(python::module &module)
    python::class_<Component> component(
       module,
       "XYs1d",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -49,37 +49,37 @@ void wrapXYs1d(python::module &module)
          python::arg("outer_domain_value") = std::nullopt,
          python::arg("axes") = std::nullopt,
          python::arg("values"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "index",
          &Component::index,
-         Component::documentation("index").c_str()
+         Component::documentation("index").data()
       )
       .def_property_readonly(
          "interpolation",
          &Component::interpolation,
-         Component::documentation("interpolation").c_str()
+         Component::documentation("interpolation").data()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::documentation("label").c_str()
+         Component::documentation("label").data()
       )
       .def_property_readonly(
          "outer_domain_value",
          &Component::outerDomainValue,
-         Component::documentation("outer_domain_value").c_str()
+         Component::documentation("outer_domain_value").data()
       )
       .def_property_readonly(
          "axes",
          python::overload_cast<>(&Component::axes),
-         Component::documentation("axes").c_str()
+         Component::documentation("axes").data()
       )
       .def_property_readonly(
          "values",
          python::overload_cast<>(&Component::values),
-         Component::documentation("values").c_str()
+         Component::documentation("values").data()
       )
    ;
 

--- a/python/src/v1.9/transport/CrossSection.python.cpp
+++ b/python/src/v1.9/transport/CrossSection.python.cpp
@@ -33,7 +33,7 @@ void wrapCrossSection(python::module &module)
    python::class_<Component> component(
       module,
       "CrossSection",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -43,12 +43,12 @@ void wrapCrossSection(python::module &module)
             const std::vector<XYS1D_REGIONS1D> &
          >(),
          python::arg("XYs1d_regions1d"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "XYs1d_regions1d",
          python::overload_cast<>(&Component::XYs1d_regions1d),
-         Component::documentation("XYs1d_regions1d").c_str()
+         Component::documentation("XYs1d_regions1d").data()
       )
    ;
 

--- a/python/src/v1.9/transport/Reaction.python.cpp
+++ b/python/src/v1.9/transport/Reaction.python.cpp
@@ -29,7 +29,7 @@ void wrapReaction(python::module &module)
    python::class_<Component> component(
       module,
       "Reaction",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -45,27 +45,27 @@ void wrapReaction(python::module &module)
          python::arg("fission_genre") = std::nullopt,
          python::arg("label"),
          python::arg("cross_section"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "endf_mt",
          &Component::ENDF_MT,
-         Component::documentation("endf_mt").c_str()
+         Component::documentation("endf_mt").data()
       )
       .def_property_readonly(
          "fission_genre",
          &Component::fissionGenre,
-         Component::documentation("fission_genre").c_str()
+         Component::documentation("fission_genre").data()
       )
       .def_property_readonly(
          "label",
          &Component::label,
-         Component::documentation("label").c_str()
+         Component::documentation("label").data()
       )
       .def_property_readonly(
          "cross_section",
          python::overload_cast<>(&Component::crossSection),
-         Component::documentation("cross_section").c_str()
+         Component::documentation("cross_section").data()
       )
    ;
 

--- a/python/src/v1.9/transport/ReactionSuite.python.cpp
+++ b/python/src/v1.9/transport/ReactionSuite.python.cpp
@@ -29,7 +29,7 @@ void wrapReactionSuite(python::module &module)
    python::class_<Component> component(
       module,
       "ReactionSuite",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -51,42 +51,42 @@ void wrapReactionSuite(python::module &module)
          python::arg("projectile_frame"),
          python::arg("target"),
          python::arg("reactions") = std::nullopt,
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "evaluation",
          &Component::evaluation,
-         Component::documentation("evaluation").c_str()
+         Component::documentation("evaluation").data()
       )
       .def_property_readonly(
          "format",
          &Component::format,
-         Component::documentation("format").c_str()
+         Component::documentation("format").data()
       )
       .def_property_readonly(
          "interaction",
          &Component::interaction,
-         Component::documentation("interaction").c_str()
+         Component::documentation("interaction").data()
       )
       .def_property_readonly(
          "projectile",
          &Component::projectile,
-         Component::documentation("projectile").c_str()
+         Component::documentation("projectile").data()
       )
       .def_property_readonly(
          "projectile_frame",
          &Component::projectileFrame,
-         Component::documentation("projectile_frame").c_str()
+         Component::documentation("projectile_frame").data()
       )
       .def_property_readonly(
          "target",
          &Component::target,
-         Component::documentation("target").c_str()
+         Component::documentation("target").data()
       )
       .def_property_readonly(
          "reactions",
          python::overload_cast<>(&Component::reactions),
-         Component::documentation("reactions").c_str()
+         Component::documentation("reactions").data()
       )
    ;
 

--- a/python/src/v1.9/transport/Reactions.python.cpp
+++ b/python/src/v1.9/transport/Reactions.python.cpp
@@ -29,7 +29,7 @@ void wrapReactions(python::module &module)
    python::class_<Component> component(
       module,
       "Reactions",
-      Component::documentation().c_str()
+      Component::documentation().data()
    );
 
    // wrap the component
@@ -39,12 +39,12 @@ void wrapReactions(python::module &module)
             const std::vector<transport::Reaction> &
          >(),
          python::arg("reaction"),
-         Component::documentation("constructor").c_str()
+         Component::documentation("constructor").data()
       )
       .def_property_readonly(
          "reaction",
          python::overload_cast<>(&Component::reaction),
-         Component::documentation("reaction").c_str()
+         Component::documentation("reaction").data()
       )
    ;
 

--- a/src/GNDStk.hpp
+++ b/src/GNDStk.hpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <charconv>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -54,6 +55,7 @@ namespace GNDStk {
 
 // basic
 #include "GNDStk/utility.hpp"
+#include "GNDStk/precision.hpp"
 #include "GNDStk/enums.hpp"
 
 // external-library wrappers

--- a/src/GNDStk/BodyText/src/detail.hpp
+++ b/src/GNDStk/BodyText/src/detail.hpp
@@ -116,26 +116,32 @@ inline constexpr bool hasLabel     = has_label    <std::decay_t<T>>::value;
 // element2element
 // -----------------------------------------------------------------------------
 
-// We don't use to_string() below, so that we can eventually deal with
-// precision; to_string() might be insufficient for our needs in that respect.
-// todo: see if GNDStk's convert() functions are appropriate for doing all
-// possible cases here, or could be extended to be.
+// todo: Determine if GNDStk's convert() functions can handle all possible
+// cases here, or could be extended to be.
 
 // arithmetic ==> string
-template<class FROM, class=std::enable_if_t<!std::is_same_v<FROM,std::string>>>
-void element2element(const FROM &from, std::string &to)
+template<class T, class = std::enable_if_t<!std::is_same_v<T,std::string>>>
+void element2element(const T &value, std::string &str)
 {
-   std::ostringstream oss;
-   oss << from; // <== precision would be relevant here
-   to = oss.str();
+   if constexpr (std::is_floating_point_v<T>) {
+      str = Precision<PrecisionContext::data,T>{}.write(value);
+   } else {
+      std::ostringstream oss;
+      oss << value;
+      str = oss.str();
+   }
 }
 
 // string ==> arithmetic
-template<class TO, class=std::enable_if_t<!std::is_same_v<TO,std::string>>>
-void element2element(const std::string &from, TO &to)
+template<class T, class = std::enable_if_t<!std::is_same_v<T,std::string>>>
+void element2element(const std::string &str, T &value)
 {
-   std::istringstream iss(from);
-   iss >> to;
+   if constexpr (std::is_floating_point_v<T>) {
+      value = Precision<PrecisionContext::data,T>{}.read(str);
+   } else {
+      std::istringstream iss(str);
+      iss >> value;
+   }
 }
 
 // arithmetic ==> arithmetic

--- a/src/GNDStk/BodyText/src/get.hpp
+++ b/src/GNDStk/BodyText/src/get.hpp
@@ -167,10 +167,18 @@ std::enable_if_t<
          to.push_back(zero);
 
       // [-----*****-----]: values from the raw string
-      T element;
       std::istringstream iss(rawstring);
-      while (iss >> element)
-         to.push_back(element);
+      if constexpr (std::is_floating_point_v<T>) {
+         std::string str;
+         while (iss >> str)
+            to.push_back(
+               detail::Precision<detail::PrecisionContext::data,T>{}.read(str)
+            );
+      } else {
+         T element;
+         while (iss >> element)
+            to.push_back(element);
+      }
 
       // Print a warning if length appears to be impossible because we already
       // have more than that number of values. (But length == 0 is ignored.)
@@ -294,9 +302,7 @@ std::enable_if_t<
    T &
 > get(const std::size_t n)
 {
-   return const_cast<T &>(
-      std::as_const(*this).template get<T>(n)
-   );
+   return const_cast<T &>(std::as_const(*this).template get<T>(n));
 }
 
 

--- a/src/GNDStk/Component/src/detail.hpp
+++ b/src/GNDStk/Component/src/detail.hpp
@@ -263,11 +263,20 @@ bool writeComponentPart(
    ) {
       value.write(os,level);
    } else {
-      // The ostringstream intermediary allows us to properly indent
-      // in the event that the printed value has internal newlines.
-      std::ostringstream oss;
-      oss << value;///precision?
-      writeComponentPart(os, level, oss.str(), label, maxlen, color);
+      if constexpr (std::is_floating_point_v<T>) {
+         writeComponentPart(
+            os, level,
+            detail::Precision<detail::PrecisionContext::metadata,T>{}.
+               write(value),
+            label, maxlen, color
+         );
+      } else {
+         // The ostringstream intermediary allows us to properly indent
+         // in the event that the printed value has internal newlines.
+         std::ostringstream oss;
+         oss << value;
+         writeComponentPart(os, level, oss.str(), label, maxlen, color);
+      }
    }
    return true;
 }

--- a/src/GNDStk/Component/test/write.test.cpp
+++ b/src/GNDStk/Component/test/write.test.cpp
@@ -26,6 +26,7 @@ SCENARIO("Component write()") {
 
          THEN ("Component's write() function gives the correct result") {
             // Component's operator<< calls its write(ostream,0)
+            njoy::GNDStk::reals << std::setprecision(8) << std::scientific;
             oss << suite << std::endl;
             CHECK(oss.str() == CorrectWriteText());
          }

--- a/src/GNDStk/Node/src/call.hpp
+++ b/src/GNDStk/Node/src/call.hpp
@@ -118,7 +118,7 @@ decltype(auto) operator()(
       // C++ doesn't have stream output for regex, which one might think
       // would print the string from which the regex was created. In fact,
       // regex might not even use, or keep, its original string initializer;
-      // thus it doesn't have, say, .str() or .c_str(). All of this is why
+      // thus it doesn't have, say, .str() or .data(). All of this is why
       // the following diagnostic doesn't print label's (regex) value.
       log::member(
          "Node(" + detail::keyname(kwd) + ",label,...) with "

--- a/src/GNDStk/Node/test/child.test.cpp
+++ b/src/GNDStk/Node/test/child.test.cpp
@@ -197,7 +197,7 @@ SCENARIO("Testing GNDStk Node child()") {
             basic::child::documentation,
             misc::child::cdata
          );
-         CHECK(0 == strncmp(descr.c_str(), "\n  8-O - 16 LANL", 16));
+         CHECK(0 == strncmp(descr.data(), "\n  8-O - 16 LANL", 16));
       }
    }
 
@@ -220,7 +220,7 @@ SCENARIO("Testing GNDStk Node child()") {
    // Child objects was the default of "no filter".) These aren't really
    // the same tests any longer, but we're leaving them in for good measure.
    auto twon = [](const Node &n)
-      { return 0 == strncmp(n(label).c_str(), "2n + ", 5); };
+      { return 0 == strncmp(n(label).data(), "2n + ", 5); };
 
    // case: <void,one>
    GIVEN("Testing Node.child(Child<void,one>[+filter][,found])") {

--- a/src/GNDStk/Node/test/many.test.cpp
+++ b/src/GNDStk/Node/test/many.test.cpp
@@ -38,7 +38,7 @@ SCENARIO("Testing GNDStk Node many()") {
 
          // filter that requires: Node has metadata label="n + *"
          auto nplus = [](const Node &n)
-            { return 0 == strncmp(n(label).c_str(), "n + ", 4); };
+            { return 0 == strncmp(n(label).data(), "n + ", 4); };
 
          // filter that requires: Node has metadata ENDF_MT="600"
          auto endf_mt_600 = [](const Node &n)

--- a/src/GNDStk/Node/test/one.test.cpp
+++ b/src/GNDStk/Node/test/one.test.cpp
@@ -41,7 +41,7 @@ SCENARIO("Testing GNDStk Node one()") {
 
       // filter for nodes that have label="2n + *"
       auto twon = [](const Node &n)
-         { return 0 == strncmp(n(label).c_str(), "2n + ", 5); };
+         { return 0 == strncmp(n(label).data(), "2n + ", 5); };
 
       // case 1
       WHEN("We test node.one(key,filter) const")

--- a/src/GNDStk/Tree/test/special.test.cpp
+++ b/src/GNDStk/Tree/test/special.test.cpp
@@ -17,7 +17,7 @@ SCENARIO("Testing comment() and comments() in GNDStk Tree") {
       --spinGroup,
       --resonanceParameters,
       --table,
-      --data
+      --child::data
    );
    const Node &c = n;
 

--- a/src/GNDStk/XML/src/write.hpp
+++ b/src/GNDStk/XML/src/write.hpp
@@ -30,7 +30,7 @@ std::ostream &write(std::ostream &os, const bool decl = true) const
       // save
       doc.save(
          os,
-         std::string(indent,' ').c_str(),
+         std::string(indent,' ').data(),
          decl
           ? pugi::format_default
           : pugi::format_default | pugi::format_no_declaration

--- a/src/GNDStk/convert/src/XML.hpp
+++ b/src/GNDStk/convert/src/XML.hpp
@@ -79,7 +79,7 @@ inline bool convert(const Node &node, XML &x)
             } else
                xdecl = x.doc.append_child(pugi::node_declaration);
             for (auto &meta : c->metadata)
-               xdecl.append_attribute(meta.first.c_str()) = meta.second.c_str();
+               xdecl.append_attribute(meta.first.data()) = meta.second.data();
             found_decl = true;
          } else {
             // looks like a regular node

--- a/src/GNDStk/convert/src/detail.hpp
+++ b/src/GNDStk/convert/src/detail.hpp
@@ -359,7 +359,7 @@ template<class NODE>
 bool write_cdata(const NODE &node, pugi::xml_node &xnode)
 {
    if (!check_special(node,"cdata")) return false;
-   xnode.append_child(pugi::node_cdata).set_value(node.meta("text").c_str());
+   xnode.append_child(pugi::node_cdata).set_value(node.meta("text").data());
    return true;
 }
 
@@ -368,7 +368,7 @@ template<class NODE>
 bool write_pcdata(const NODE &node, pugi::xml_node &xnode)
 {
    if (!check_special(node,"pcdata")) return false;
-   xnode.append_child(pugi::node_pcdata).set_value(node.meta("text").c_str());
+   xnode.append_child(pugi::node_pcdata).set_value(node.meta("text").data());
    return true;
 }
 
@@ -377,7 +377,7 @@ template<class NODE>
 bool write_comment(const NODE &node, pugi::xml_node &xnode)
 {
    if (!check_special(node,"comment")) return false;
-   xnode.append_child(pugi::node_comment).set_value(node.meta("text").c_str());
+   xnode.append_child(pugi::node_comment).set_value(node.meta("text").data());
    return true;
 }
 
@@ -388,11 +388,11 @@ template<class NODE>
 bool node2xml(const NODE &node, pugi::xml_node &x)
 {
    // name
-   pugi::xml_node xnode = x.append_child(node.name.c_str());
+   pugi::xml_node xnode = x.append_child(node.name.data());
 
    // metadata
    for (auto &meta : node.metadata)
-      xnode.append_attribute(meta.first.c_str()) = meta.second.c_str();
+      xnode.append_attribute(meta.first.data()) = meta.second.data();
 
    // children
    for (auto &child : node.children) {

--- a/src/GNDStk/precision.hpp
+++ b/src/GNDStk/precision.hpp
@@ -1,0 +1,78 @@
+
+// -----------------------------------------------------------------------------
+// This file contains constructs related to the reading and writing
+// of floating-point numbers.
+// -----------------------------------------------------------------------------
+
+// Some detail classes that underlie our I/O manipulators
+#include "GNDStk/precision/src/detail.hpp"
+
+
+// -----------------------------------------------------------------------------
+// For users
+// context::real << ...
+// Example: metadata::floats << ...
+// -----------------------------------------------------------------------------
+
+// We'll have:
+//    floats, doubles, long doubles
+//    reals: all of the above
+// in each of:
+//    GNDStk::metadata::
+//    GNDStk::data:: (in body text, i.e. XML "plain character data")
+//    GNDStk::
+// the last meaning for both metadata:: and data::.
+
+// ------------------------
+// GNDStk::metadata::
+// ------------------------
+
+namespace metadata {
+inline detail::Precision<detail::PrecisionContext::metadata, float>
+   floats;
+inline detail::Precision<detail::PrecisionContext::metadata, double>
+   doubles;
+inline detail::Precision<detail::PrecisionContext::metadata, long double>
+   longdoubles, &quads = longdoubles;
+inline detail::Precision<detail::PrecisionContext::metadata, void>
+   reals;
+}
+
+// ------------------------
+// GNDStk::data::
+// ------------------------
+
+namespace data {
+inline detail::Precision<detail::PrecisionContext::data, float>
+   floats;
+inline detail::Precision<detail::PrecisionContext::data, double>
+   doubles;
+inline detail::Precision<detail::PrecisionContext::data, long double>
+   longdoubles, &quads = longdoubles;
+inline detail::Precision<detail::PrecisionContext::data, void>
+   reals;
+}
+
+// ------------------------
+// GNDStk::
+// ------------------------
+
+inline detail::Precision<detail::PrecisionContext::general, float>
+   floats;
+inline detail::Precision<detail::PrecisionContext::general, double>
+   doubles;
+inline detail::Precision<detail::PrecisionContext::general, long double>
+   longdoubles, &quads = longdoubles;
+inline detail::Precision<detail::PrecisionContext::general, void>
+   reals;
+
+
+// -----------------------------------------------------------------------------
+// For users
+// ... << manipulator
+// Example: ... << GNDStk::scientific
+// -----------------------------------------------------------------------------
+
+inline const detail::Fixed      fixed;
+inline const detail::Scientific scientific;
+inline const detail::Shortest   shortest;

--- a/src/GNDStk/precision/src/detail.hpp
+++ b/src/GNDStk/precision/src/detail.hpp
@@ -127,18 +127,27 @@ class Precision {
    // If it doesn't, 0 converts to double and the second version is called.
    // Thus the final parameter helps with overloading; its value isn't used.
 
+#ifdef GNDSTK_PRECISION
+   // OK, apparently it may be impossible to make the SFINAE work as intended
+   // in the event that the std::chars_format enum class doesn't even exist,
+   // so that the token [chars_format] (which is used in both the SFINAE and
+   // in the function body itself) doesn't even make sense to the compiler.
+   // Perhaps we can find a way around this. For now, given that we don't want
+   // to_chars() and from_chars() to be GNDStk's default at this time, we'll
+   // use an #ifdef to remove this code altogether unless someone wants it.
+
    template<
       class T,
       class = std::enable_if_t<std::is_same_v<
          decltype(std::to_chars(
             (char*)0, (char*)0, T{})),
          std::to_chars_result
-      >>/*,
+      >>,
       class = std::enable_if_t<std::is_same_v<
          decltype(std::to_chars(
             (char*)0, (char*)0, T{}, std::chars_format::fixed)),
          std::to_chars_result
-         >>*/
+      >>
    >
    bool write(const T &value, std::string &str, int)
    {
@@ -158,6 +167,7 @@ class Precision {
       str = chars.data(); // ensure output std::string stops at \0
       return true;
    }
+#endif
 
    template<class T>
    bool write(const T &, std::string &, double)

--- a/src/GNDStk/precision/src/detail.hpp
+++ b/src/GNDStk/precision/src/detail.hpp
@@ -1,0 +1,359 @@
+
+namespace detail {
+
+// -----------------------------------------------------------------------------
+// Enumerators
+// -----------------------------------------------------------------------------
+
+// PrecisionContext
+enum class PrecisionContext {
+   metadata, // for GNDStk metadata values
+   data,     // for "body text", a.k.a. XML "plain character data"
+   general   // one-stop shop to set the formatting for both of the above
+};
+
+// PrecisionType
+enum class PrecisionType {
+   // use formatting available through C++ output stream manipulators...
+   none,
+
+   // use std::to_chars()...
+   fixed,
+   scientific,
+   shortest
+};
+
+
+
+// -----------------------------------------------------------------------------
+// Classes for GNDStk's own floating-point manipulators
+// These align with our three custom PrecisionType values
+// -----------------------------------------------------------------------------
+
+class Fixed { };
+class Scientific { };
+class Shortest { };
+
+
+
+// -----------------------------------------------------------------------------
+// Precision class
+// -----------------------------------------------------------------------------
+
+/*
+DISCUSSION
+
+The goal that underlies the current code is as follows. Somewhere, we have
+a floating-point number (a float, a double, or a long double), and we wish
+to produce a decimal representation of that number.
+
+What we plan to *do* with the decimal representation isn't relevant here.
+Perhaps we'll write it to std::cout, or to some other output stream. Perhaps
+we don't wish to do anything with it stream-wise, but instead plan to place
+it into a GNDStk Tree. Here, now, we're concerned only with the process of
+producing a decimal representation of the number.
+
+Naturally, for the decimal representation, we'll use a std::string.
+
+So: given a floating-point number, we want to produce a string. We already
+know that C++ provides more than one way to do this. A basic and reasonably
+flexible way is to begin with an output string stream (a std::ostringstream),
+use its operator<< to write the floating-point number, and then call the
+std::ostringstream's str() function to get the std::string. Prior to <<-ing
+the number, we could set up properties we want, such as precision, by using
+I/O manipulators. For example, oss << std::setprecision(10) << thenumber,
+where oss is the std::ostringstream.
+
+GNDStk provides that methodology. To do so, objects of the below Precision
+class contain a std::ostringstream, oss, the properties of which can be set
+in the usual way (call << on the Precision object; it passes them on to oss.)
+
+However, for the fun and profit of our users, we wish to provide something
+extra. Sufficiently recent C++-17 enabled compilers provide the to_chars()
+set of functions, with "round trip guarantees" for decimal representations
+of floating-point numbers, as well as the ability to produce the *shortest*
+such representation. The round-trip guarantee essentially means that if we
+start with, say, a double-precision number (at the time of this writing,
+probably 64 bits in memory), use to_chars() to make a string, and then read
+the string with from_chars(), then we're guaranteed to recover exactly the
+same 64 bits in memory; that is, precisely the same double we began with.
+Along with the "shortest representation" requirement, we can write shortest-
+possible decimal representations, with *no* loss of information.
+
+Aside: the guarantee requires that from_chars(), not necessarily any string-
+to-floating-point process, be used on the string produced by to_chars().
+Also, obviously, such a requirement might be broken if different compilers,
+computing platforms, or floating-point sizes are used for to_chars() versus
+from_chars(). Under those circumstances, no algorithm in the universe could
+make the guarantee.
+
+todo Write more details, and provide some examples. Discuss how *input* is
+involved, and the relationship between input and output that someone should
+understand when using this system.
+*/
+
+
+
+// -----------------------------------------------------------------------------
+// Precision<CONTEXT,REAL>
+// In the given context: the given floating-point type
+// -----------------------------------------------------------------------------
+
+template<PrecisionContext CONTEXT, class REAL>
+class Precision {
+
+   // The purpose of the following std::ostringstream is to "store" I/O
+   // properties that someone might set by using manipulators. Those properties
+   // might be used by write(), depending on the "otype" flag below.
+   static std::ostringstream oss;
+
+   // Similar, but for input
+   static std::istringstream iss;
+
+   // The value of the following determines whether oss (above) will be used
+   // by write() to create a string, or whether write() will use to_chars().
+   static PrecisionType otype;
+
+   // for input
+   static PrecisionType itype;
+
+public:
+
+   // todo Needs comment
+   bool tie = false;
+
+   // write
+   std::string write(const REAL &value)
+   {
+      if (otype == PrecisionType::none) {
+         oss.str("");
+         oss.clear();
+         oss << value; // uses properties in oss
+         return oss.str();
+      }
+
+      // todo: Perhaps use a REAL-dependent sufficient size, not just 100 :-/
+      std::string chars(100,'\0');
+
+      if (otype == PrecisionType::fixed)
+         std::to_chars(chars.data(), chars.data()+chars.size(), value,
+                       std::chars_format::fixed);
+      else if (otype == PrecisionType::scientific)
+         std::to_chars(chars.data(), chars.data()+chars.size(), value,
+                       std::chars_format::scientific);
+      else
+         std::to_chars(chars.data(), chars.data()+chars.size(), value);
+
+      return chars.data(); // ensure output std::string stops at \0
+   }
+
+   // read
+   REAL read(const std::string &str)
+   {
+      REAL value;
+
+      if (itype == PrecisionType::none) {
+         iss.str(str);
+         iss.clear();
+         iss >> value; // uses properties in iss
+         return value;
+      }
+
+      // Provide a clean slate for from_chars(), which skips white space but
+      // doesn't like '+'. So, we'll skip the white space, and then any '+'.
+      const char *first = str.data();
+      while (isspace(*first))
+         first++;
+      if (*first == '+')
+         first++;
+
+      std::from_chars(first, str.data()+str.size(), value);
+      return value;
+   }
+
+   // ------------------------
+   // For C++ I/O stream
+   // manipulators
+   // ------------------------
+
+   // operator<<
+   // Relays the general C++ manipulator to the std::ostringstream.
+   // Important: with this (detail::) class, use write(), above, for creating
+   // a string with a decimal representation of a floating-point number. Such
+   // a string might be used with your own output stream somewhere, or perhaps
+   // used for some other purpose for which you'd use such a string. Here, we
+   // presume that the argument is a stream manipulator of some sort. If it's
+   // something that would print - a number, say - then that's not what this
+   // function is about. See the discussion earlier in this file.
+   template<class MANIP>
+   Precision &operator<<(const MANIP &manip)
+   {
+      otype = PrecisionType::none;
+      oss << manip;
+      return *this;
+   }
+
+   // operator>>
+   template<class MANIP>
+   Precision &operator>>(const MANIP &manip)
+   {
+      itype = PrecisionType::none;
+      iss >> manip;
+      return *this;
+   }
+
+   // ------------------------
+   // For special GNDStk
+   // manipulators
+   // ------------------------
+
+   // operator<<
+   // According to the given GNDStk manipulator, arranges for write()
+   // to use GNDStk's formatting capabilities.
+   Precision &operator<<(const Fixed &)
+   {
+      otype = PrecisionType::fixed;
+      if (tie) itype = PrecisionType::fixed;
+      return *this;
+   }
+
+   Precision &operator<<(const Scientific &)
+   {
+      otype = PrecisionType::scientific;
+      if (tie) itype = PrecisionType::fixed;
+      return *this;
+   }
+
+   Precision &operator<<(const Shortest &)
+   {
+      otype = PrecisionType::shortest;
+      if (tie) itype = PrecisionType::fixed;
+      return *this;
+   }
+
+   // operator>>
+   Precision &operator>>(const Fixed &)
+   {
+      itype = PrecisionType::fixed;
+      if (tie) otype = PrecisionType::fixed;
+      return *this;
+   }
+
+   Precision &operator>>(const Scientific &)
+   {
+      itype = PrecisionType::scientific;
+      if (tie) otype = PrecisionType::fixed;
+      return *this;
+   }
+
+   Precision &operator>>(const Shortest &)
+   {
+      itype = PrecisionType::shortest;
+      if (tie) otype = PrecisionType::fixed;
+      return *this;
+   }
+};
+
+template<PrecisionContext CONTEXT, class REAL>
+std::ostringstream Precision<CONTEXT,REAL>::oss;
+
+template<PrecisionContext CONTEXT, class REAL>
+std::istringstream Precision<CONTEXT,REAL>::iss;
+
+template<PrecisionContext CONTEXT, class REAL>
+PrecisionType Precision<CONTEXT,REAL>::otype = PrecisionType::shortest;
+
+template<PrecisionContext CONTEXT, class REAL>
+PrecisionType Precision<CONTEXT,REAL>::itype = PrecisionType::shortest;
+
+
+
+// -----------------------------------------------------------------------------
+// Precision<CONTEXT,void>
+// In the given context: float, double, and long double
+// -----------------------------------------------------------------------------
+
+template<PrecisionContext CONTEXT>
+class Precision<CONTEXT,void> {
+public:
+   // operator<<
+   template<class MANIP>
+   Precision &operator<<(const MANIP &manip)
+   {
+      Precision<CONTEXT, float      >{} << manip;
+      Precision<CONTEXT, double     >{} << manip;
+      Precision<CONTEXT, long double>{} << manip;
+      return *this;
+   }
+
+   // operator>>
+   template<class MANIP>
+   Precision &operator>>(const MANIP &manip)
+   {
+      Precision<CONTEXT, float      >{} >> manip;
+      Precision<CONTEXT, double     >{} >> manip;
+      Precision<CONTEXT, long double>{} >> manip;
+      return *this;
+   }
+};
+
+
+
+// -----------------------------------------------------------------------------
+// Precision<general,REAL>
+// In metadata and data: the given floating-point type
+// -----------------------------------------------------------------------------
+
+template<class REAL>
+class Precision<PrecisionContext::general,REAL> {
+public:
+   // operator<<
+   template<class MANIP>
+   Precision &operator<<(const MANIP &manip)
+   {
+      Precision<PrecisionContext::metadata, REAL>{} << manip;
+      Precision<PrecisionContext::data,     REAL>{} << manip;
+      return *this;
+   }
+
+   // operator>>
+   template<class MANIP>
+   Precision &operator>>(const MANIP &manip)
+   {
+      Precision<PrecisionContext::metadata, REAL>{} >> manip;
+      Precision<PrecisionContext::data,     REAL>{} >> manip;
+      return *this;
+   }
+};
+
+
+
+// -----------------------------------------------------------------------------
+// Precision<general,void>
+// In metadata and data: float, double, and long double
+// And, this disambiguates Precision's partial specializations
+// -----------------------------------------------------------------------------
+
+template<>
+class Precision<PrecisionContext::general,void> {
+public:
+   // operator<<
+   template<class MANIP>
+   Precision &operator<<(const MANIP &manip)
+   {
+      Precision<PrecisionContext::metadata, void>{} << manip;
+      Precision<PrecisionContext::data,     void>{} << manip;
+      return *this;
+   }
+
+   // operator>>
+   template<class MANIP>
+   Precision &operator>>(const MANIP &manip)
+   {
+      Precision<PrecisionContext::metadata, void>{} >> manip;
+      Precision<PrecisionContext::data,     void>{} >> manip;
+      return *this;
+   }
+};
+
+} // namespace detail

--- a/src/GNDStk/precision/src/detail.hpp
+++ b/src/GNDStk/precision/src/detail.hpp
@@ -133,12 +133,12 @@ class Precision {
          decltype(std::to_chars(
             (char*)0, (char*)0, T{})),
          std::to_chars_result
-      >>,
+      >>/*,
       class = std::enable_if_t<std::is_same_v<
          decltype(std::to_chars(
             (char*)0, (char*)0, T{}, std::chars_format::fixed)),
          std::to_chars_result
-      >>
+         >>*/
    >
    bool write(const T &value, std::string &str, int)
    {

--- a/src/GNDStk/string2type.hpp
+++ b/src/GNDStk/string2type.hpp
@@ -35,7 +35,6 @@ convert(string,type) for some existing C++ container types.
 */
 
 
-
 // -----------------------------------------------------------------------------
 // convert(istream,T)
 // Default: use operator>>
@@ -45,7 +44,15 @@ convert(string,type) for some existing C++ container types.
 template<class T>
 inline void convert(std::istream &is, T &value)
 {
-   is >> value;
+   if constexpr (std::is_floating_point_v<T>) {
+      std::string str;
+      is >> str;
+      value = detail::Precision<
+         detail::PrecisionContext::metadata,T
+      >{}.read(str);
+   } else {
+      is >> value;
+   }
 }
 
 // pair
@@ -90,7 +97,6 @@ inline void convert(std::istream &is, std::pair<X,Y> &p)
 #undef GNDSTK_CONVERT
 
 
-
 // -----------------------------------------------------------------------------
 // convert(string,T)
 // Default: make an istringstream from the string, then use convert(istream,*)
@@ -110,13 +116,11 @@ inline void convert(const std::string &str, T &value)
    }
 }
 
-
 // string
 inline void convert(const std::string &str, std::string &value)
 {
    value = str;
 }
-
 
 // bool
 inline void convert(const std::string &str, bool &value)
@@ -137,7 +141,6 @@ inline void convert(const std::string &str, bool &value)
    }
 }
 
-
 // miscellaneous
 // string-to-T specializations that may be faster than our default
 #define GNDSTK_CONVERT(fun,TYPE) \
@@ -153,9 +156,5 @@ inline void convert(const std::string &str, bool &value)
    GNDSTK_CONVERT(stoul,  unsigned) // apparently there's no std::stou()
    GNDSTK_CONVERT(stoul,  unsigned long)
    GNDSTK_CONVERT(stoull, unsigned long long)
-
-   GNDSTK_CONVERT(stof,   float)
-   GNDSTK_CONVERT(stod,   double)
-   GNDSTK_CONVERT(stold,  long double)
 
 #undef GNDSTK_CONVERT

--- a/src/GNDStk/utility.hpp
+++ b/src/GNDStk/utility.hpp
@@ -233,7 +233,7 @@ inline void info(const std::string &str, Args &&...args)
 {
    if (GNDStk::info) {
       const std::string msg = detail::diagnostic("info",str);
-      Log::info(msg.c_str(), std::forward<Args>(args)...);
+      Log::info(msg.data(), std::forward<Args>(args)...);
    }
 }
 
@@ -243,7 +243,7 @@ inline void warning(const std::string &str, Args &&...args)
 {
    if (GNDStk::warning) {
       const std::string msg = detail::diagnostic("warning",str);
-      Log::warning(msg.c_str(), std::forward<Args>(args)...);
+      Log::warning(msg.data(), std::forward<Args>(args)...);
    }
 }
 
@@ -252,7 +252,7 @@ template<class... Args>
 inline void error(const std::string &str, Args &&...args)
 {
    const std::string msg = detail::diagnostic("error",str);
-   Log::error(msg.c_str(), std::forward<Args>(args)...);
+   Log::error(msg.data(), std::forward<Args>(args)...);
 }
 
 // debug
@@ -261,7 +261,7 @@ inline void debug(const std::string &str, Args &&...args)
 {
    if (GNDStk::debug) {
       const std::string msg = detail::diagnostic("debug",str);
-      Log::debug(msg.c_str(), std::forward<Args>(args)...);
+      Log::debug(msg.data(), std::forward<Args>(args)...);
    }
 }
 
@@ -278,7 +278,7 @@ inline void function(const std::string &str, Args &&...args)
    if (GNDStk::context) {
       const std::string msg =
          detail::diagnostic("info", "function " + str, "Context");
-      Log::info(msg.c_str(), std::forward<Args>(args)...);
+      Log::info(msg.data(), std::forward<Args>(args)...);
    }
 }
 
@@ -289,7 +289,7 @@ inline void member(const std::string &str, Args &&...args)
    if (GNDStk::context) {
       const std::string msg =
          detail::diagnostic("info", "member function " + str, "Context");
-      Log::info(msg.c_str(), std::forward<Args>(args)...);
+      Log::info(msg.data(), std::forward<Args>(args)...);
    }
 }
 
@@ -300,7 +300,7 @@ inline void ctor(const std::string &str, Args &&...args)
    if (GNDStk::context) {
       const std::string msg =
          detail::diagnostic("info", "constructor " + str, "Context");
-      Log::info(msg.c_str(), std::forward<Args>(args)...);
+      Log::info(msg.data(), std::forward<Args>(args)...);
    }
 }
 
@@ -311,7 +311,7 @@ inline void assign(const std::string &str, Args &&...args)
    if (GNDStk::context) {
       const std::string msg =
          detail::diagnostic("info", "assignment " + str, "Context");
-      Log::info(msg.c_str(), std::forward<Args>(args)...);
+      Log::info(msg.data(), std::forward<Args>(args)...);
    }
 }
 

--- a/src/GNDStk/v1.9/containers/Grid.hpp
+++ b/src/GNDStk/v1.9/containers/Grid.hpp
@@ -109,7 +109,7 @@ public:
     { return content.index; }
 
    // interpolation
-   const enums::Interpolation
+   enums::Interpolation
    interpolation() const
     { return content.interpolation.value(); }
    enums::Interpolation

--- a/src/GNDStk/v1.9/containers/Values.hpp
+++ b/src/GNDStk/v1.9/containers/Values.hpp
@@ -89,7 +89,7 @@ public:
     { return content.length; }
 
    // start
-   const Integer32
+   Integer32
    start() const
     { return content.start.value(); }
    Integer32

--- a/src/GNDStk/v1.9/containers/XYs1d.hpp
+++ b/src/GNDStk/v1.9/containers/XYs1d.hpp
@@ -104,7 +104,7 @@ public:
     { return content.index; }
 
    // interpolation
-   const enums::Interpolation
+   enums::Interpolation
    interpolation() const
     { return content.interpolation.value(); }
    enums::Interpolation


### PR DESCRIPTION
This passes all the CI tests now. It turned out that there was an earlier glitch in the SFINAE scheme for excluding `to_chars` and `from_chars` calls it they weren't available. The glitch related to a certain `enum` that apparently isn't in `std::` in the older libraries. In the context of an `enum`, template argument deduction isn't involved, and SFINAE isn't applicable. There might be a way to finagle the code to work with SFINAE, but if there is, I haven't figured it out. For compatibility with older compilers, we're not even using `to_chars` and `from_chars` right now. So, I put an `#ifdef` and `#endif` around the problematic function, so that we can move ahead with higher-priority things. The remaining precision code does everything I believe you (@whaeck) needed, so you should be able to start using it right now.
